### PR TITLE
3 plugin prepare to submit results for qualifying

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -12,9 +12,6 @@ class CloudLink():
         self._rhapi = rhapi
 
     def send_individual_heat(self,args):
-        self.getSingleGroup(args)
-
-    def getSingleGroup(self,args):
         db = self._rhapi.db
         heat = db.heat_by_id(args["heat_id"])
 


### PR DESCRIPTION
When heat alter is triggered, the heat details are compiled and prepared for cloud sync. 

Supports manual heat creation or generated heat. Also supports manual pilot assignment or auto frequency. 

Though heats are synced 1 by 1, payload is created as a list to support future expansion of total heat / class syncronization.