### PR TITLE
added class name to payload so later cloud manage

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -28,11 +28,13 @@ class CloudLink():
         heatname = str(heatobj.name)
         heatid = str(heatobj.id)
         heatclassid = str(heatobj.class_id)
+        heatclassname = self.getClassName(heatclassid,db)
         racechannels = self.getRaceChannels()
 
         thisheat = {
             "eventid": self.CL_EVENT_ID,
             "classid": heatclassid,
+            "classname":heatclassname,
             "heatid": heatid,
             "heatname": heatname,
             "slots":[]
@@ -55,6 +57,11 @@ class CloudLink():
             thisheat["slots"].append(thisslot)
 
         return thisheat
+
+    def getClassName(self, classid, db):
+        thisclass = db.raceclass_by_id(classid)
+        return thisclass.name
+
 
 
     def getRaceChannels(self):


### PR DESCRIPTION
This introduces class name to the payload. Original design is to let the race director match classes in rotorhazard. To keep things simple, matching will be done in cloud instead. Therfore, class ID and class name are required on class side so director can do the matching. 

With matching done, cloud can determine which group of heats follow the qualifying design, double elimination design and single elimination design as well as other such future enhancements. 