### PR TITLE
feat: in-timer event registration form

### DIFF
--- a/custom_plugins/cloudlink/cloudlink.py
+++ b/custom_plugins/cloudlink/cloudlink.py
@@ -194,12 +194,12 @@ class CloudLink():
 
             if slot.node_index is not None:
 
-                channel = racechannels[slot.node_index] 
+                channel = racechannels[slot.node_index] if slot.node_index < len(racechannels) else "0"
                 pilotcallsign = "-"
                 if slot.pilot_id != 0:
-                                        
                     pilot = db.pilot_by_id(slot.pilot_id)
-                    pilotcallsign = pilot.callsign
+                    if pilot is not None:
+                        pilotcallsign = pilot.callsign
                 thisslot = {
                     "nodeindex": slot.node_index,
                     "channel": channel,

--- a/custom_plugins/cloudlink/cloudlink.py
+++ b/custom_plugins/cloudlink/cloudlink.py
@@ -4,6 +4,7 @@ import logging
 from sqlalchemy.ext.declarative import DeclarativeMeta
 from RHUI import UIField, UIFieldType
 from .datamanager import ClDataManager
+from .setup_blueprint import create_blueprint
 try:
     from .config import CL_API_ENDPOINT as _CONFIGURED_ENDPOINT
 except ImportError:
@@ -18,6 +19,14 @@ class CloudLink():
         self.logger = logging.getLogger(__name__)
         self._rhapi = rhapi
         self.cldatamanger = ClDataManager(self._rhapi)
+
+        # Register the setup Blueprint immediately (before STARTUP fires)
+        try:
+            bp = create_blueprint(self._rhapi)
+            self._rhapi.ui.blueprint_add(bp)
+            self.logger.info("CloudLink setup blueprint registered at /cloudlink/setup")
+        except Exception as e:
+            self.logger.error(f"CloudLink: failed to register blueprint: {e}")
         
     def init_plugin(self,args):
 
@@ -50,9 +59,29 @@ class CloudLink():
         ui.register_panel("cloud-link", "Cloudlink", "format")
         ui.register_quickbutton("cloud-link", "send-all-button", "Resync", self.resync_new)
 
+        # Setup link — shown at the top of the panel
+        keys = self.getEventKeys()
+        if keys["notempty"]:
+            setup_link_md = (
+                '<a href="/cloudlink/setup" target="_self" '
+                'style="display:inline-block;padding:6px 14px;background:#ee7a28;'
+                'color:#fff;border-radius:4px;font-size:0.85rem;font-weight:600;'
+                'text-decoration:none;">⚙️ Edit / Re-register Event</a>'
+            )
+        else:
+            setup_link_md = (
+                '<a href="/cloudlink/setup" target="_self" '
+                'style="display:inline-block;padding:6px 14px;background:#ee7a28;'
+                'color:#fff;border-radius:4px;font-size:0.85rem;font-weight:600;'
+                'text-decoration:none;">🚀 Register New Event</a>'
+                '<p style="font-size:0.78rem;color:#9ab;margin:6px 0 0;">'
+                'Or enter keys manually below.</p>'
+            )
+        ui.register_markdown("cloud-link", "cl-setup-link", setup_link_md)
+
         cl_enableplugin = UIField(name = 'cl-enable-plugin', label = 'Enable Cloud Link Plugin', field_type = UIFieldType.CHECKBOX, desc = "Enable or disable this plugin. Unchecking this box will stop all communication with the Cloudlink server.")
-        cl_eventid = UIField(name = 'cl-event-id', label = 'Cloud Link Event ID', field_type = UIFieldType.TEXT, desc = "Event must be registered at rhcloudlink.com")
-        cl_eventkey = UIField(name = 'cl-event-key', label = 'Cloud Link Event Private Key', field_type = UIFieldType.TEXT, desc = "Authentication key provided by Cloudlink during event registration.")
+        cl_eventid = UIField(name = 'cl-event-id', label = 'Cloud Link Event ID', field_type = UIFieldType.TEXT, desc = "Auto-populated after registration, or enter manually.")
+        cl_eventkey = UIField(name = 'cl-event-key', label = 'Cloud Link Event Private Key', field_type = UIFieldType.TEXT, desc = "Auto-populated after registration, or enter manually.")
 
         fields = self._rhapi.fields
         fields.register_option(cl_enableplugin, "cloud-link")

--- a/custom_plugins/cloudlink/cloudlink.py
+++ b/custom_plugins/cloudlink/cloudlink.py
@@ -59,24 +59,17 @@ class CloudLink():
         ui.register_panel("cloud-link", "Cloudlink", "format")
         ui.register_quickbutton("cloud-link", "send-all-button", "Resync", self.resync_new)
 
-        # Setup link — shown at the top of the panel
+        # Setup link — styled to match native RH quickbuttons
         keys = self.getEventKeys()
         if keys["notempty"]:
-            setup_link_md = (
-                '<a href="/cloudlink/setup" target="_self" '
-                'style="display:inline-block;padding:6px 14px;background:#ee7a28;'
-                'color:#fff;border-radius:4px;font-size:0.85rem;font-weight:600;'
-                'text-decoration:none;">⚙️ Edit / Re-register Event</a>'
-            )
+            label = "Edit / Re-register Event"
         else:
-            setup_link_md = (
-                '<a href="/cloudlink/setup" target="_self" '
-                'style="display:inline-block;padding:6px 14px;background:#ee7a28;'
-                'color:#fff;border-radius:4px;font-size:0.85rem;font-weight:600;'
-                'text-decoration:none;">🚀 Register New Event</a>'
-                '<p style="font-size:0.78rem;color:#9ab;margin:6px 0 0;">'
-                'Or enter keys manually below.</p>'
-            )
+            label = "Register New Event"
+        setup_link_md = (
+            '<div class="control-set">'
+            f'<a href="/cloudlink/setup" class="button-like" target="_self">{label}</a>'
+            '</div>'
+        )
         ui.register_markdown("cloud-link", "cl-setup-link", setup_link_md)
 
         cl_enableplugin = UIField(name = 'cl-enable-plugin', label = 'Enable Cloud Link Plugin', field_type = UIFieldType.CHECKBOX, desc = "Enable or disable this plugin. Unchecking this box will stop all communication with the Cloudlink server.")

--- a/custom_plugins/cloudlink/manifest.json
+++ b/custom_plugins/cloudlink/manifest.json
@@ -5,7 +5,7 @@
     "author_uri" : "https://github.com/vikibaarathi",
     "description" : "Instant pilot grouping, channel changes, ranking and tournament bracket visualization platform",
     "documentation_uri": "https://github.com/vikibaarathi/RHCloudlink-plugin/blob/main/README.md",
-    "version" : "1.4.0",
+    "version" : "1.4.1",
     "required_rhapi_version" : "1.2",
     "category": ["Event Management"]
 }

--- a/custom_plugins/cloudlink/setup_blueprint.py
+++ b/custom_plugins/cloudlink/setup_blueprint.py
@@ -1,0 +1,86 @@
+import os
+import random
+import string
+import logging
+from flask import Blueprint, render_template, request, jsonify
+
+logger = logging.getLogger(__name__)
+
+
+def create_blueprint(rhapi):
+    """
+    Creates and returns the CloudLink Flask Blueprint.
+    Handles the in-timer event registration UI and mock API.
+    Phase 2: replace mock_register() with real CloudLink API calls.
+    """
+    bp = Blueprint(
+        'cloudlink_setup',
+        __name__,
+        template_folder=os.path.join(os.path.dirname(__file__), 'templates'),
+        url_prefix='/cloudlink'
+    )
+
+    # ------------------------------------------------------------------
+    # GET /cloudlink/setup  — render the registration form
+    # ------------------------------------------------------------------
+    @bp.route('/setup')
+    def setup():
+        eventid = rhapi.db.option('cl-event-id') or ''
+        eventkey = rhapi.db.option('cl-event-key') or ''
+        return render_template(
+            'cloudlink/setup.html',
+            eventid=eventid,
+            eventkey=eventkey,
+        )
+
+    # ------------------------------------------------------------------
+    # POST /cloudlink/register  — mock registration (Phase 1)
+    # Phase 2: call CloudLink API, get real eventid + privatekey back
+    # ------------------------------------------------------------------
+    @bp.route('/register', methods=['POST'])
+    def register():
+        try:
+            event_name    = request.form.get('eventname', '').strip()
+            event_date    = request.form.get('eventdate', '').strip()
+            event_city    = request.form.get('eventcity', '').strip()
+            event_country = request.form.get('eventcountry', '').strip()
+            event_desc    = request.form.get('eventdesc', '').strip()
+            image_mode    = request.form.get('image_mode', 'rh_logo')
+            image_url     = request.form.get('image_url', '').strip()
+
+            if not event_name:
+                return jsonify({'success': False, 'error': 'Event name is required'}), 400
+
+            # --- MOCK (Phase 1) ---
+            # Simulates what the CloudLink API will return after real registration.
+            # Replace this block in Phase 2 with actual HTTP call to POST /register.
+            mock_eventid = ''.join(random.choices(string.ascii_lowercase + string.digits, k=5))
+            mock_key     = ''.join(random.choices(string.ascii_lowercase + string.digits, k=5))
+            # --- END MOCK ---
+
+            # Save keys to RH database options so the main panel picks them up
+            rhapi.db.set_option('cl-event-id', mock_eventid)
+            rhapi.db.set_option('cl-event-key', mock_key)
+
+            logger.info(f'[CloudLink] Mock event registered: {mock_eventid} for "{event_name}"')
+
+            return jsonify({
+                'success': True,
+                'eventid': mock_eventid,
+                'privatekey': mock_key,
+            })
+
+        except Exception as e:
+            logger.error(f'[CloudLink] Registration error: {e}')
+            return jsonify({'success': False, 'error': str(e)}), 500
+
+    # ------------------------------------------------------------------
+    # POST /cloudlink/clear-keys  — reset keys (start over)
+    # ------------------------------------------------------------------
+    @bp.route('/clear-keys', methods=['POST'])
+    def clear_keys():
+        rhapi.db.set_option('cl-event-id', '')
+        rhapi.db.set_option('cl-event-key', '')
+        return jsonify({'success': True})
+
+    return bp

--- a/custom_plugins/cloudlink/setup_blueprint.py
+++ b/custom_plugins/cloudlink/setup_blueprint.py
@@ -110,24 +110,24 @@ def create_blueprint(rhapi):
                         image_file = None  # skip upload if nothing selected
 
                 elif image_mode == 'rh_logo':
-                    # Read the RH logo SVG from the static files on disk
-                    rh_logo_path = os.path.join(
-                        os.path.dirname(__file__), '..', '..', '..', '..', 'src', 'server',
-                        'static', 'image', 'RotorHazard Logo.svg'
-                    )
-                    rh_logo_path = os.path.normpath(rh_logo_path)
-                    if os.path.exists(rh_logo_path):
-                        with open(rh_logo_path, 'rb') as f:
-                            image_file = f.read()
-                        content_type = 'image/svg+xml'
-                    else:
-                        logger.warning('[CloudLink] RH logo file not found, skipping image upload')
+                    # Fetch the RH logo from the local server using the same host:port
+                    # request.host_url gives e.g. "http://localhost:5005/"
+                    try:
+                        logo_url = request.host_url.rstrip('/') + '/static/image/RotorHazard Logo.svg'
+                        logo_resp = requests.get(logo_url, timeout=5)
+                        if logo_resp.status_code == 200:
+                            image_file = logo_resp.content
+                            content_type = 'image/svg+xml'
+                        else:
+                            logger.warning(f'[CloudLink] Could not fetch RH logo (HTTP {logo_resp.status_code}), skipping image upload')
+                    except Exception as e:
+                        logger.warning(f'[CloudLink] RH logo fetch failed: {e}, skipping image upload')
 
                 if image_file is not None:
-                    # Get presigned URL
+                    # Get presigned URL — API expects contentType in JSON body
                     url_resp = requests.post(
                         f'{CL_API_ENDPOINT}/event/{event_id}/upload-url',
-                        params={'content-type': content_type},
+                        json={'contentType': content_type},
                         headers={'X-Private-Key': priv_key},
                         timeout=10
                     )

--- a/custom_plugins/cloudlink/setup_blueprint.py
+++ b/custom_plugins/cloudlink/setup_blueprint.py
@@ -1,18 +1,26 @@
 import os
-import random
-import string
 import logging
+import requests
 from flask import Blueprint, render_template, request, jsonify
 
 logger = logging.getLogger(__name__)
 
+# RH logo path — served statically by RotorHazard
+RH_LOGO_URL = '/static/image/RotorHazard Logo.svg'
+
 
 def create_blueprint(rhapi):
     """
-    Creates and returns the CloudLink Flask Blueprint.
-    Handles the in-timer event registration UI and mock API.
-    Phase 2: replace mock_register() with real CloudLink API calls.
+    CloudLink Flask Blueprint — in-timer event registration UI.
+    Wired to the real CloudLink API (Phase 2).
     """
+
+    # Pull the configured API endpoint from the plugin's own config
+    try:
+        from .config import CL_API_ENDPOINT
+    except ImportError:
+        CL_API_ENDPOINT = 'https://api.rhcloudlink.com'
+
     bp = Blueprint(
         'cloudlink_setup',
         __name__,
@@ -25,17 +33,12 @@ def create_blueprint(rhapi):
     # ------------------------------------------------------------------
     @bp.route('/setup')
     def setup():
-        eventid = rhapi.db.option('cl-event-id') or ''
+        eventid  = rhapi.db.option('cl-event-id') or ''
         eventkey = rhapi.db.option('cl-event-key') or ''
-        return render_template(
-            'cloudlink/setup.html',
-            eventid=eventid,
-            eventkey=eventkey,
-        )
+        return render_template('cloudlink/setup.html', eventid=eventid, eventkey=eventkey)
 
     # ------------------------------------------------------------------
-    # POST /cloudlink/register  — mock registration (Phase 1)
-    # Phase 2: call CloudLink API, get real eventid + privatekey back
+    # POST /cloudlink/register  — real registration via CloudLink API
     # ------------------------------------------------------------------
     @bp.route('/register', methods=['POST'])
     def register():
@@ -45,31 +48,135 @@ def create_blueprint(rhapi):
             event_city    = request.form.get('eventcity', '').strip()
             event_country = request.form.get('eventcountry', '').strip()
             event_desc    = request.form.get('eventdesc', '').strip()
+            email_id      = request.form.get('emailid', '').strip()
             image_mode    = request.form.get('image_mode', 'rh_logo')
             image_url     = request.form.get('image_url', '').strip()
 
             if not event_name:
                 return jsonify({'success': False, 'error': 'Event name is required'}), 400
+            if not email_id:
+                return jsonify({'success': False, 'error': 'Email address is required'}), 400
 
-            # --- MOCK (Phase 1) ---
-            # Simulates what the CloudLink API will return after real registration.
-            # Replace this block in Phase 2 with actual HTTP call to POST /register.
-            mock_eventid = ''.join(random.choices(string.ascii_lowercase + string.digits, k=5))
-            mock_key     = ''.join(random.choices(string.ascii_lowercase + string.digits, k=5))
-            # --- END MOCK ---
+            # ── Step 1: Determine initial logo URL ──────────────────────
+            # For URL mode we can pass it straight to /register.
+            # For file/rh_logo we register first (gets default logo), then upload.
+            initial_logo_url = None
+            if image_mode == 'url' and image_url:
+                initial_logo_url = image_url
 
-            # Save keys to RH database options so the main panel picks them up
-            rhapi.db.set_option('cl-event-id', mock_eventid)
-            rhapi.db.set_option('cl-event-key', mock_key)
+            # ── Step 2: Register the event ──────────────────────────────
+            payload = {
+                'emailid':      email_id,
+                'eventname':    event_name,
+                'eventdate':    event_date,
+                'eventcity':    event_city,
+                'eventcountry': event_country,
+                'eventdesc':    event_desc,
+                'eventpublic':  'private',
+            }
+            if initial_logo_url:
+                payload['eventlogourl'] = initial_logo_url
 
-            logger.info(f'[CloudLink] Mock event registered: {mock_eventid} for "{event_name}"')
+            reg_resp = requests.post(
+                f'{CL_API_ENDPOINT}/register',
+                json=payload,
+                timeout=15
+            )
+
+            if reg_resp.status_code != 200:
+                logger.error(f'[CloudLink] Registration failed: {reg_resp.status_code} {reg_resp.text}')
+                return jsonify({'success': False, 'error': f'Registration failed: {reg_resp.status_code}'}), 502
+
+            reg_data  = reg_resp.json()
+            event_id  = reg_data.get('eventid') or reg_data.get('data', {}).get('eventid')
+            priv_key  = reg_data.get('privatekey') or reg_data.get('data', {}).get('privatekey')
+
+            if not event_id or not priv_key:
+                return jsonify({'success': False, 'error': 'Invalid response from CloudLink API'}), 502
+
+            # ── Step 3: Handle image upload (file or RH logo) ───────────
+            final_logo_url = initial_logo_url  # already set for URL mode
+
+            if image_mode in ('upload', 'rh_logo'):
+                image_file = None
+                content_type = 'image/svg+xml'
+
+                if image_mode == 'upload':
+                    image_file = request.files.get('image_file')
+                    if image_file and image_file.filename:
+                        content_type = image_file.content_type or 'image/jpeg'
+                    else:
+                        image_file = None  # skip upload if nothing selected
+
+                elif image_mode == 'rh_logo':
+                    # Read the RH logo SVG from the static files on disk
+                    rh_logo_path = os.path.join(
+                        os.path.dirname(__file__), '..', '..', '..', '..', 'src', 'server',
+                        'static', 'image', 'RotorHazard Logo.svg'
+                    )
+                    rh_logo_path = os.path.normpath(rh_logo_path)
+                    if os.path.exists(rh_logo_path):
+                        with open(rh_logo_path, 'rb') as f:
+                            image_file = f.read()
+                        content_type = 'image/svg+xml'
+                    else:
+                        logger.warning('[CloudLink] RH logo file not found, skipping image upload')
+
+                if image_file is not None:
+                    # Get presigned URL
+                    url_resp = requests.post(
+                        f'{CL_API_ENDPOINT}/event/{event_id}/upload-url',
+                        params={'content-type': content_type},
+                        headers={'X-Private-Key': priv_key},
+                        timeout=10
+                    )
+
+                    if url_resp.status_code == 200:
+                        url_data    = url_resp.json()
+                        upload_url  = url_data.get('uploadUrl') or url_data.get('data', {}).get('uploadUrl')
+                        image_s3url = url_data.get('imageUrl')  or url_data.get('data', {}).get('imageUrl')
+
+                        if upload_url:
+                            # Upload directly to S3
+                            file_data = image_file if isinstance(image_file, bytes) else image_file.read()
+                            s3_resp = requests.put(
+                                upload_url,
+                                data=file_data,
+                                headers={'Content-Type': content_type},
+                                timeout=30
+                            )
+                            if s3_resp.status_code in (200, 204):
+                                final_logo_url = image_s3url
+                                # Patch the event with the final logo URL
+                                requests.patch(
+                                    f'{CL_API_ENDPOINT}/event/{event_id}',
+                                    json={'eventlogourl': final_logo_url},
+                                    headers={'X-Private-Key': priv_key},
+                                    timeout=10
+                                )
+                                logger.info(f'[CloudLink] Image uploaded for {event_id}: {final_logo_url}')
+                            else:
+                                logger.warning(f'[CloudLink] S3 upload failed ({s3_resp.status_code}), continuing without image')
+                    else:
+                        logger.warning(f'[CloudLink] Could not get presigned URL ({url_resp.status_code}), continuing without image')
+
+            # ── Step 4: Save keys to RH ─────────────────────────────────
+            rhapi.db.set_option('cl-event-id', event_id)
+            rhapi.db.set_option('cl-event-key', priv_key)
+
+            logger.info(f'[CloudLink] Event registered: {event_id} for "{event_name}"')
 
             return jsonify({
-                'success': True,
-                'eventid': mock_eventid,
-                'privatekey': mock_key,
+                'success':    True,
+                'eventid':    event_id,
+                'privatekey': priv_key,
+                'logourl':    final_logo_url,
             })
 
+        except requests.exceptions.ConnectionError:
+            return jsonify({'success': False, 'error': 'Cannot reach CloudLink API. Check internet connection.'}), 503
+        except requests.exceptions.Timeout:
+            return jsonify({'success': False, 'error': 'CloudLink API timed out. Please try again.'}), 504
         except Exception as e:
             logger.error(f'[CloudLink] Registration error: {e}')
             return jsonify({'success': False, 'error': str(e)}), 500

--- a/custom_plugins/cloudlink/setup_blueprint.py
+++ b/custom_plugins/cloudlink/setup_blueprint.py
@@ -49,6 +49,7 @@ def create_blueprint(rhapi):
             event_country = request.form.get('eventcountry', '').strip()
             event_desc    = request.form.get('eventdesc', '').strip()
             email_id      = request.form.get('emailid', '').strip()
+            event_public  = request.form.get('eventpublic', 'private').strip()
             image_mode    = request.form.get('image_mode', 'rh_logo')
             image_url     = request.form.get('image_url', '').strip()
 
@@ -72,7 +73,7 @@ def create_blueprint(rhapi):
                 'eventcity':    event_city,
                 'eventcountry': event_country,
                 'eventdesc':    event_desc,
-                'eventpublic':  'private',
+                'eventpublic':  event_public if event_public in ('public', 'private') else 'private',
             }
             if initial_logo_url:
                 payload['eventlogourl'] = initial_logo_url

--- a/custom_plugins/cloudlink/setup_blueprint.py
+++ b/custom_plugins/cloudlink/setup_blueprint.py
@@ -162,8 +162,8 @@ def create_blueprint(rhapi):
                         logger.warning(f'[CloudLink] Could not get presigned URL ({url_resp.status_code}), continuing without image')
 
             # ── Step 4: Save keys to RH ─────────────────────────────────
-            rhapi.db.set_option('cl-event-id', event_id)
-            rhapi.db.set_option('cl-event-key', priv_key)
+            rhapi.db.option_set('cl-event-id', event_id)
+            rhapi.db.option_set('cl-event-key', priv_key)
 
             logger.info(f'[CloudLink] Event registered: {event_id} for "{event_name}"')
 
@@ -187,8 +187,8 @@ def create_blueprint(rhapi):
     # ------------------------------------------------------------------
     @bp.route('/clear-keys', methods=['POST'])
     def clear_keys():
-        rhapi.db.set_option('cl-event-id', '')
-        rhapi.db.set_option('cl-event-key', '')
+        rhapi.db.option_set('cl-event-id', '')
+        rhapi.db.option_set('cl-event-key', '')
         return jsonify({'success': True})
 
     return bp

--- a/custom_plugins/cloudlink/setup_blueprint.py
+++ b/custom_plugins/cloudlink/setup_blueprint.py
@@ -43,13 +43,14 @@ def create_blueprint(rhapi):
     @bp.route('/register', methods=['POST'])
     def register():
         try:
-            event_name    = request.form.get('eventname', '').strip()
-            event_date    = request.form.get('eventdate', '').strip()
-            event_city    = request.form.get('eventcity', '').strip()
-            event_country = request.form.get('eventcountry', '').strip()
-            event_desc    = request.form.get('eventdesc', '').strip()
-            email_id      = request.form.get('emailid', '').strip()
-            event_public  = request.form.get('eventpublic', 'private').strip()
+            event_name     = request.form.get('eventname', '').strip()
+            event_date     = request.form.get('eventdate', '').strip()
+            event_end_date = request.form.get('eventenddate', '').strip() or event_date
+            event_city     = request.form.get('eventcity', '').strip()
+            event_country  = request.form.get('eventcountry', '').strip()
+            event_desc     = request.form.get('eventdesc', '').strip()
+            email_id       = request.form.get('emailid', '').strip()
+            event_public   = request.form.get('eventpublic', 'private').strip()
             image_mode    = request.form.get('image_mode', 'rh_logo')
             image_url     = request.form.get('image_url', '').strip()
 
@@ -67,13 +68,14 @@ def create_blueprint(rhapi):
 
             # ── Step 2: Register the event ──────────────────────────────
             payload = {
-                'emailid':      email_id,
-                'eventname':    event_name,
-                'eventdate':    event_date,
-                'eventcity':    event_city,
-                'eventcountry': event_country,
-                'eventdesc':    event_desc,
-                'eventpublic':  event_public if event_public in ('public', 'private') else 'private',
+                'emailid':       email_id,
+                'eventname':     event_name,
+                'eventdate':     event_date,
+                'eventenddate':  event_end_date,
+                'eventcity':     event_city,
+                'eventcountry':  event_country,
+                'eventdesc':     event_desc,
+                'eventpublic':   event_public if event_public in ('public', 'private') else 'private',
             }
             if initial_logo_url:
                 payload['eventlogourl'] = initial_logo_url
@@ -98,44 +100,34 @@ def create_blueprint(rhapi):
             # ── Step 3: Handle image upload (file or RH logo) ───────────
             final_logo_url = initial_logo_url  # already set for URL mode
 
-            if image_mode in ('upload', 'rh_logo'):
+            if image_mode == 'upload':
                 image_file = None
-                content_type = 'image/svg+xml'
+                content_type = 'image/jpeg'
 
-                if image_mode == 'upload':
-                    image_file = request.files.get('image_file')
-                    if image_file and image_file.filename:
-                        content_type = image_file.content_type or 'image/jpeg'
+                uploaded = request.files.get('image_file')
+                if uploaded and uploaded.filename:
+                    content_type = uploaded.content_type or 'image/jpeg'
+                    # Presign endpoint only accepts jpeg/png/webp
+                    if content_type not in ('image/jpeg', 'image/png', 'image/webp'):
+                        logger.warning(f'[CloudLink] Unsupported file type {content_type}, skipping image upload')
                     else:
-                        image_file = None  # skip upload if nothing selected
+                        image_file = uploaded
 
-                elif image_mode == 'rh_logo':
-                    # Fetch the RH logo from the local server using the same host:port
-                    # request.host_url gives e.g. "http://localhost:5005/"
-                    try:
-                        logo_url = request.host_url.rstrip('/') + '/static/image/RotorHazard Logo.svg'
-                        logo_resp = requests.get(logo_url, timeout=5)
-                        if logo_resp.status_code == 200:
-                            image_file = logo_resp.content
-                            content_type = 'image/svg+xml'
-                        else:
-                            logger.warning(f'[CloudLink] Could not fetch RH logo (HTTP {logo_resp.status_code}), skipping image upload')
-                    except Exception as e:
-                        logger.warning(f'[CloudLink] RH logo fetch failed: {e}, skipping image upload')
+            if image_mode in ('upload',):  # rh_logo mode skips upload (uses API default)
 
                 if image_file is not None:
-                    # Get presigned URL — API expects contentType in JSON body
+                    # Get presigned URL via new endpoint — no auth required
+                    file_name = getattr(image_file, 'filename', 'image.jpg') if not isinstance(image_file, bytes) else 'image.svg'
                     url_resp = requests.post(
-                        f'{CL_API_ENDPOINT}/event/{event_id}/upload-url',
-                        json={'contentType': content_type},
-                        headers={'X-Private-Key': priv_key},
+                        f'{CL_API_ENDPOINT}/uploads/presign',
+                        json={'fileName': file_name, 'contentType': content_type},
                         timeout=10
                     )
 
                     if url_resp.status_code == 200:
                         url_data    = url_resp.json()
-                        upload_url  = url_data.get('uploadUrl') or url_data.get('data', {}).get('uploadUrl')
-                        image_s3url = url_data.get('imageUrl')  or url_data.get('data', {}).get('imageUrl')
+                        upload_url  = url_data.get('data', {}).get('uploadUrl')
+                        image_s3url = url_data.get('data', {}).get('publicUrl')
 
                         if upload_url:
                             # Upload directly to S3

--- a/custom_plugins/cloudlink/templates/cloudlink/setup.html
+++ b/custom_plugins/cloudlink/templates/cloudlink/setup.html
@@ -387,7 +387,7 @@
       <div class="cl-img-options">
 
         <!-- Option 1: RH Logo -->
-        <div class="cl-img-option selected" id="opt-rh-logo" onclick="selectImageMode('rh_logo')">
+        <div class="cl-img-option selected" id="opt-rh_logo" onclick="selectImageMode('rh_logo')">
           <input type="radio" name="image_mode" value="rh_logo" checked>
           <div class="cl-img-option-body">
             <div class="cl-img-option-label">Use RotorHazard Logo</div>

--- a/custom_plugins/cloudlink/templates/cloudlink/setup.html
+++ b/custom_plugins/cloudlink/templates/cloudlink/setup.html
@@ -1,0 +1,577 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CloudLink — Event Setup</title>
+
+  <!-- Reuse RotorHazard's stylesheet -->
+  <link rel="stylesheet" href="/static/rotorhazard.css">
+  <link rel="icon" type="image/png" sizes="32x32" href="/static/image/favicon-32x32.png">
+
+  <style>
+    /* ── Page layout ── */
+    body { padding: 0; margin: 0; }
+
+    .cl-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 14px 24px;
+      border-bottom: 2px solid var(--color-interface-border, #2a4a6b);
+      background: var(--color-panel-bg, #1a3550);
+      flex-wrap: wrap;
+      gap: 10px;
+    }
+    .cl-header-title {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+    }
+    .cl-header-title h1 {
+      font-size: 1.3rem;
+      margin: 0;
+      color: var(--color-text-heading, #fff);
+      letter-spacing: 0.03em;
+    }
+    .cl-badge {
+      font-size: 0.65rem;
+      background: #ee7a28;
+      color: #fff;
+      border-radius: 4px;
+      padding: 2px 6px;
+      font-weight: 700;
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+    }
+    .cl-back-link {
+      font-size: 0.85rem;
+      color: #ee7a28;
+      text-decoration: none;
+    }
+    .cl-back-link:hover { text-decoration: underline; }
+
+    /* ── Main container ── */
+    .cl-container {
+      max-width: 680px;
+      margin: 32px auto;
+      padding: 0 20px 60px;
+    }
+
+    /* ── Section cards ── */
+    .cl-card {
+      background: var(--color-panel-bg, #1e3d5c);
+      border: 1px solid var(--color-interface-border, #2a4a6b);
+      border-radius: 6px;
+      padding: 24px;
+      margin-bottom: 20px;
+    }
+    .cl-card h2 {
+      font-size: 0.85rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: #ee7a28;
+      margin: 0 0 18px;
+    }
+
+    /* ── Form fields ── */
+    .cl-field { margin-bottom: 16px; }
+    .cl-field label {
+      display: block;
+      font-size: 0.8rem;
+      color: var(--color-text-secondary, #9ab);
+      margin-bottom: 5px;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+    }
+    .cl-field input[type="text"],
+    .cl-field input[type="date"],
+    .cl-field input[type="url"],
+    .cl-field textarea {
+      width: 100%;
+      box-sizing: border-box;
+      background: var(--color-input-bg, #132d45);
+      border: 1px solid var(--color-interface-border, #2a4a6b);
+      border-radius: 4px;
+      color: var(--color-text, #dde);
+      padding: 9px 12px;
+      font-size: 0.95rem;
+      font-family: inherit;
+      outline: none;
+      transition: border-color 0.15s;
+    }
+    .cl-field input:focus,
+    .cl-field textarea:focus {
+      border-color: #ee7a28;
+    }
+    .cl-field textarea { resize: vertical; min-height: 80px; }
+    .cl-row { display: flex; gap: 16px; }
+    .cl-row .cl-field { flex: 1; }
+
+    /* ── Image options ── */
+    .cl-img-options { display: flex; flex-direction: column; gap: 12px; }
+    .cl-img-option {
+      display: flex;
+      align-items: flex-start;
+      gap: 12px;
+      padding: 14px;
+      border: 1px solid var(--color-interface-border, #2a4a6b);
+      border-radius: 5px;
+      cursor: pointer;
+      transition: border-color 0.15s, background 0.15s;
+    }
+    .cl-img-option:hover { border-color: #ee7a28; }
+    .cl-img-option.selected {
+      border-color: #ee7a28;
+      background: rgba(238,122,40,0.07);
+    }
+    .cl-img-option input[type="radio"] { margin-top: 3px; accent-color: #ee7a28; }
+    .cl-img-option-body { flex: 1; }
+    .cl-img-option-label {
+      font-size: 0.9rem;
+      font-weight: 600;
+      color: var(--color-text, #dde);
+      margin-bottom: 4px;
+    }
+    .cl-img-option-desc {
+      font-size: 0.78rem;
+      color: var(--color-text-secondary, #9ab);
+    }
+    .cl-img-option-input { margin-top: 10px; display: none; }
+    .cl-img-option-input.visible { display: block; }
+
+    /* RH logo preview */
+    .cl-rh-logo-preview {
+      width: 80px;
+      opacity: 0.7;
+      margin-top: 8px;
+    }
+    .selected .cl-rh-logo-preview { opacity: 1; }
+
+    /* File input styling */
+    .cl-file-input {
+      display: block;
+      width: 100%;
+      box-sizing: border-box;
+      background: var(--color-input-bg, #132d45);
+      border: 1px dashed var(--color-interface-border, #2a4a6b);
+      border-radius: 4px;
+      color: var(--color-text, #dde);
+      padding: 9px 12px;
+      font-size: 0.9rem;
+      cursor: pointer;
+    }
+    .cl-file-hint {
+      font-size: 0.72rem;
+      color: var(--color-text-secondary, #9ab);
+      margin-top: 5px;
+    }
+
+    /* ── Buttons ── */
+    .cl-btn {
+      display: inline-block;
+      padding: 10px 24px;
+      border-radius: 4px;
+      font-size: 0.95rem;
+      font-weight: 600;
+      cursor: pointer;
+      border: none;
+      transition: opacity 0.15s, background 0.15s;
+      font-family: inherit;
+      letter-spacing: 0.03em;
+    }
+    .cl-btn-primary {
+      background: #ee7a28;
+      color: #fff;
+    }
+    .cl-btn-primary:hover { opacity: 0.88; }
+    .cl-btn-primary:disabled { opacity: 0.4; cursor: not-allowed; }
+    .cl-btn-secondary {
+      background: transparent;
+      color: #ee7a28;
+      border: 1px solid #ee7a28;
+    }
+    .cl-btn-secondary:hover { background: rgba(238,122,40,0.1); }
+    .cl-btn-row {
+      display: flex;
+      gap: 12px;
+      align-items: center;
+      margin-top: 4px;
+    }
+
+    /* ── Existing keys card ── */
+    .cl-keys-grid { display: flex; flex-direction: column; gap: 12px; }
+    .cl-key-item label {
+      display: block;
+      font-size: 0.75rem;
+      color: var(--color-text-secondary, #9ab);
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      margin-bottom: 4px;
+    }
+    .cl-key-value {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+    .cl-key-box {
+      flex: 1;
+      background: var(--color-input-bg, #132d45);
+      border: 1px solid var(--color-interface-border, #2a4a6b);
+      border-radius: 4px;
+      padding: 8px 12px;
+      font-family: monospace;
+      font-size: 1rem;
+      color: #ee7a28;
+      letter-spacing: 0.08em;
+    }
+    .cl-copy-btn {
+      background: none;
+      border: 1px solid var(--color-interface-border, #2a4a6b);
+      border-radius: 4px;
+      color: var(--color-text-secondary, #9ab);
+      padding: 7px 10px;
+      cursor: pointer;
+      font-size: 0.75rem;
+      white-space: nowrap;
+    }
+    .cl-copy-btn:hover { border-color: #ee7a28; color: #ee7a28; }
+
+    /* ── Success state ── */
+    #success-state { display: none; }
+    .cl-success-icon {
+      font-size: 2.5rem;
+      text-align: center;
+      margin-bottom: 12px;
+    }
+    .cl-success-message {
+      text-align: center;
+      color: var(--color-text-secondary, #9ab);
+      font-size: 0.9rem;
+      margin-bottom: 24px;
+    }
+    .cl-success-message strong { color: var(--color-text, #dde); }
+
+    /* ── Status message ── */
+    .cl-status {
+      font-size: 0.85rem;
+      padding: 10px 14px;
+      border-radius: 4px;
+      margin-top: 14px;
+      display: none;
+    }
+    .cl-status.error { background: rgba(200,60,60,0.15); border: 1px solid rgba(200,60,60,0.4); color: #f88; }
+    .cl-status.info  { background: rgba(238,122,40,0.1);  border: 1px solid rgba(238,122,40,0.3); color: #ee7a28; }
+
+    /* ── Spinner ── */
+    .cl-spinner {
+      display: none;
+      width: 16px; height: 16px;
+      border: 2px solid rgba(255,255,255,0.2);
+      border-top-color: #fff;
+      border-radius: 50%;
+      animation: spin 0.7s linear infinite;
+      vertical-align: middle;
+      margin-right: 6px;
+    }
+    .cl-btn.loading .cl-spinner { display: inline-block; }
+    .cl-btn.loading .cl-btn-text { opacity: 0.7; }
+    @keyframes spin { to { transform: rotate(360deg); } }
+  </style>
+</head>
+<body>
+
+<!-- ── Header ── -->
+<div class="cl-header">
+  <div class="cl-header-title">
+    <h1>CloudLink <span class="cl-badge">Event Setup</span></h1>
+  </div>
+  <a class="cl-back-link" href="/format">← Back to Format</a>
+</div>
+
+<div class="cl-container">
+
+  <!-- ── EXISTING KEYS (shown if already registered) ── -->
+  {% if eventid and eventkey %}
+  <div class="cl-card" id="existing-keys-card">
+    <h2>✅ Event Already Registered</h2>
+    <div class="cl-keys-grid">
+      <div class="cl-key-item">
+        <label>Event ID</label>
+        <div class="cl-key-value">
+          <div class="cl-key-box" id="display-eventid">{{ eventid }}</div>
+          <button class="cl-copy-btn" onclick="copyText('{{ eventid }}', this)">Copy</button>
+        </div>
+      </div>
+      <div class="cl-key-item">
+        <label>Private Key</label>
+        <div class="cl-key-value">
+          <div class="cl-key-box" id="display-eventkey">{{ eventkey }}</div>
+          <button class="cl-copy-btn" onclick="copyText('{{ eventkey }}', this)">Copy</button>
+        </div>
+      </div>
+    </div>
+    <div class="cl-btn-row" style="margin-top: 20px;">
+      <a class="cl-btn cl-btn-primary" href="/format">Done — Back to Format</a>
+      <button class="cl-btn cl-btn-secondary" onclick="showRegisterForm()">Register a Different Event</button>
+    </div>
+  </div>
+  {% endif %}
+
+  <!-- ── REGISTRATION FORM ── -->
+  <div id="register-form-section" {% if eventid and eventkey %}style="display:none"{% endif %}>
+
+    <!-- Event Details -->
+    <div class="cl-card">
+      <h2>Event Details</h2>
+
+      <div class="cl-field">
+        <label>Event Name *</label>
+        <input type="text" id="eventname" placeholder="e.g. UGKL Drone Race Round 3" />
+      </div>
+
+      <div class="cl-row">
+        <div class="cl-field">
+          <label>Date</label>
+          <input type="date" id="eventdate" />
+        </div>
+        <div class="cl-field">
+          <label>City</label>
+          <input type="text" id="eventcity" placeholder="e.g. Kuala Lumpur" />
+        </div>
+      </div>
+
+      <div class="cl-field">
+        <label>Country</label>
+        <input type="text" id="eventcountry" placeholder="e.g. Malaysia" />
+      </div>
+
+      <div class="cl-field">
+        <label>Description</label>
+        <textarea id="eventdesc" placeholder="Tell pilots what this event is about..."></textarea>
+      </div>
+    </div>
+
+    <!-- Image -->
+    <div class="cl-card">
+      <h2>Event Image</h2>
+      <div class="cl-img-options">
+
+        <!-- Option 1: RH Logo -->
+        <div class="cl-img-option selected" id="opt-rh-logo" onclick="selectImageMode('rh_logo')">
+          <input type="radio" name="image_mode" value="rh_logo" checked>
+          <div class="cl-img-option-body">
+            <div class="cl-img-option-label">Use RotorHazard Logo</div>
+            <div class="cl-img-option-desc">Uses the RotorHazard logo as the event image.</div>
+            <img src="/static/image/RotorHazard Logo.svg" class="cl-rh-logo-preview" alt="RotorHazard Logo">
+          </div>
+        </div>
+
+        <!-- Option 2: Upload file -->
+        <div class="cl-img-option" id="opt-upload" onclick="selectImageMode('upload')">
+          <input type="radio" name="image_mode" value="upload">
+          <div class="cl-img-option-body">
+            <div class="cl-img-option-label">Upload a File</div>
+            <div class="cl-img-option-desc">Upload a poster or chapter logo from this timer machine.</div>
+            <div class="cl-img-option-input" id="upload-input">
+              <input type="file" id="image_file" class="cl-file-input" accept="image/jpeg,image/png,image/webp,image/svg+xml" onclick="event.stopPropagation()">
+              <div class="cl-file-hint">JPEG, PNG, WebP or SVG · Max 5 MB</div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Option 3: URL -->
+        <div class="cl-img-option" id="opt-url" onclick="selectImageMode('url')">
+          <input type="radio" name="image_mode" value="url">
+          <div class="cl-img-option-body">
+            <div class="cl-img-option-label">Enter a URL</div>
+            <div class="cl-img-option-desc">Link directly to an image hosted online.</div>
+            <div class="cl-img-option-input" id="url-input">
+              <input type="url" id="image_url" placeholder="https://example.com/poster.jpg" onclick="event.stopPropagation()">
+            </div>
+          </div>
+        </div>
+
+      </div>
+    </div>
+
+    <!-- Submit -->
+    <div class="cl-card">
+      <div class="cl-btn-row">
+        <button class="cl-btn cl-btn-primary" id="register-btn" onclick="submitRegistration()">
+          <span class="cl-spinner"></span>
+          <span class="cl-btn-text">Register Event</span>
+        </button>
+        {% if eventid and eventkey %}
+        <button class="cl-btn cl-btn-secondary" onclick="cancelRegister()">Cancel</button>
+        {% endif %}
+      </div>
+      <div class="cl-status" id="status-msg"></div>
+    </div>
+
+  </div><!-- /register-form-section -->
+
+  <!-- ── SUCCESS STATE ── -->
+  <div id="success-state">
+    <div class="cl-card">
+      <div class="cl-success-icon">🎉</div>
+      <div class="cl-success-message">
+        Event registered! Your keys have been saved to the timer automatically.<br>
+        <strong>Head back to the Format page to start racing.</strong>
+      </div>
+      <div class="cl-keys-grid">
+        <div class="cl-key-item">
+          <label>Event ID</label>
+          <div class="cl-key-value">
+            <div class="cl-key-box" id="new-eventid">—</div>
+            <button class="cl-copy-btn" onclick="copyText(document.getElementById('new-eventid').textContent, this)">Copy</button>
+          </div>
+        </div>
+        <div class="cl-key-item">
+          <label>Private Key</label>
+          <div class="cl-key-value">
+            <div class="cl-key-box" id="new-eventkey">—</div>
+            <button class="cl-copy-btn" onclick="copyText(document.getElementById('new-eventkey').textContent, this)">Copy</button>
+          </div>
+        </div>
+      </div>
+      <div class="cl-btn-row" style="margin-top: 24px;">
+        <a class="cl-btn cl-btn-primary" href="/format">Done — Back to Format</a>
+        <button class="cl-btn cl-btn-secondary" onclick="registerAnother()">Register Another</button>
+      </div>
+    </div>
+  </div>
+
+</div><!-- /cl-container -->
+
+<script>
+  var currentImageMode = 'rh_logo';
+
+  function selectImageMode(mode) {
+    currentImageMode = mode;
+    ['rh_logo', 'upload', 'url'].forEach(function(m) {
+      var optEl = document.getElementById('opt-' + m);
+      var radio = optEl.querySelector('input[type="radio"]');
+      if (m === mode) {
+        optEl.classList.add('selected');
+        radio.checked = true;
+      } else {
+        optEl.classList.remove('selected');
+        radio.checked = false;
+      }
+    });
+    // show/hide sub-inputs
+    var uploadInput = document.getElementById('upload-input');
+    var urlInput = document.getElementById('url-input');
+    uploadInput.classList.toggle('visible', mode === 'upload');
+    urlInput.classList.toggle('visible', mode === 'url');
+  }
+
+  function showStatus(msg, type) {
+    var el = document.getElementById('status-msg');
+    el.textContent = msg;
+    el.className = 'cl-status ' + type;
+    el.style.display = 'block';
+  }
+  function hideStatus() {
+    document.getElementById('status-msg').style.display = 'none';
+  }
+
+  function setLoading(loading) {
+    var btn = document.getElementById('register-btn');
+    if (loading) {
+      btn.classList.add('loading');
+      btn.disabled = true;
+    } else {
+      btn.classList.remove('loading');
+      btn.disabled = false;
+    }
+  }
+
+  function submitRegistration() {
+    var eventname = document.getElementById('eventname').value.trim();
+    if (!eventname) {
+      showStatus('Event name is required.', 'error');
+      return;
+    }
+
+    hideStatus();
+    setLoading(true);
+
+    var formData = new FormData();
+    formData.append('eventname',    eventname);
+    formData.append('eventdate',    document.getElementById('eventdate').value);
+    formData.append('eventcity',    document.getElementById('eventcity').value.trim());
+    formData.append('eventcountry', document.getElementById('eventcountry').value.trim());
+    formData.append('eventdesc',    document.getElementById('eventdesc').value.trim());
+    formData.append('image_mode',   currentImageMode);
+
+    if (currentImageMode === 'upload') {
+      var fileInput = document.getElementById('image_file');
+      if (fileInput.files.length > 0) {
+        formData.append('image_file', fileInput.files[0]);
+      }
+    } else if (currentImageMode === 'url') {
+      formData.append('image_url', document.getElementById('image_url').value.trim());
+    }
+
+    fetch('/cloudlink/register', {
+      method: 'POST',
+      body: formData
+    })
+    .then(function(res) { return res.json(); })
+    .then(function(data) {
+      setLoading(false);
+      if (data.success) {
+        document.getElementById('new-eventid').textContent  = data.eventid;
+        document.getElementById('new-eventkey').textContent = data.privatekey;
+        document.getElementById('register-form-section').style.display = 'none';
+        var existingCard = document.getElementById('existing-keys-card');
+        if (existingCard) existingCard.style.display = 'none';
+        document.getElementById('success-state').style.display = 'block';
+      } else {
+        showStatus('Error: ' + (data.error || 'Registration failed'), 'error');
+      }
+    })
+    .catch(function(err) {
+      setLoading(false);
+      showStatus('Network error. Check the timer connection.', 'error');
+    });
+  }
+
+  function showRegisterForm() {
+    document.getElementById('existing-keys-card').style.display = 'none';
+    document.getElementById('register-form-section').style.display = 'block';
+  }
+
+  function cancelRegister() {
+    document.getElementById('register-form-section').style.display = 'none';
+    document.getElementById('existing-keys-card').style.display = 'block';
+  }
+
+  function registerAnother() {
+    document.getElementById('success-state').style.display = 'none';
+    document.getElementById('register-form-section').style.display = 'block';
+    document.getElementById('eventname').value = '';
+    document.getElementById('eventdate').value = '';
+    document.getElementById('eventcity').value = '';
+    document.getElementById('eventcountry').value = '';
+    document.getElementById('eventdesc').value = '';
+    selectImageMode('rh_logo');
+  }
+
+  function copyText(text, btn) {
+    navigator.clipboard.writeText(text).then(function() {
+      var orig = btn.textContent;
+      btn.textContent = 'Copied!';
+      setTimeout(function() { btn.textContent = orig; }, 1500);
+    });
+  }
+
+  // Init: set default date to today
+  var today = new Date().toISOString().split('T')[0];
+  document.getElementById('eventdate').value = today;
+</script>
+
+</body>
+</html>

--- a/custom_plugins/cloudlink/templates/cloudlink/setup.html
+++ b/custom_plugins/cloudlink/templates/cloudlink/setup.html
@@ -161,6 +161,21 @@
       font-size: 0.9rem;
       cursor: pointer;
     }
+    .cl-field select {
+      width: 100%;
+      box-sizing: border-box;
+      background: var(--color-input-bg, #132d45);
+      border: 1px solid var(--color-interface-border, #2a4a6b);
+      border-radius: 4px;
+      color: var(--color-text, #dde);
+      padding: 9px 12px;
+      font-size: 0.95rem;
+      font-family: inherit;
+      outline: none;
+      cursor: pointer;
+      appearance: none;
+    }
+    .cl-field select:focus { border-color: #ee7a28; }
     .cl-file-hint {
       font-size: 0.72rem;
       color: var(--color-text-secondary, #9ab);
@@ -346,9 +361,18 @@
         </div>
       </div>
 
-      <div class="cl-field">
-        <label>Country</label>
-        <input type="text" id="eventcountry" placeholder="e.g. Malaysia" />
+      <div class="cl-row">
+        <div class="cl-field">
+          <label>Country</label>
+          <input type="text" id="eventcountry" placeholder="e.g. Malaysia" />
+        </div>
+        <div class="cl-field">
+          <label>Event Visibility</label>
+          <select id="eventpublic">
+            <option value="private">🔒 Private — invite only</option>
+            <option value="public">🌐 Public — listed on CloudLink</option>
+          </select>
+        </div>
       </div>
 
       <div class="cl-field">
@@ -515,6 +539,7 @@
     formData.append('eventcity',    document.getElementById('eventcity').value.trim());
     formData.append('eventcountry', document.getElementById('eventcountry').value.trim());
     formData.append('eventdesc',    document.getElementById('eventdesc').value.trim());
+    formData.append('eventpublic',  document.getElementById('eventpublic').value);
     formData.append('image_mode',   currentImageMode);
 
     if (currentImageMode === 'upload') {
@@ -568,6 +593,7 @@
     document.getElementById('eventdate').value = '';
     document.getElementById('eventcity').value = '';
     document.getElementById('eventcountry').value = '';
+    document.getElementById('eventpublic').value = 'private';
     document.getElementById('eventdesc').value = '';
     selectImageMode('rh_logo');
   }

--- a/custom_plugins/cloudlink/templates/cloudlink/setup.html
+++ b/custom_plugins/cloudlink/templates/cloudlink/setup.html
@@ -352,27 +352,32 @@
 
       <div class="cl-row">
         <div class="cl-field">
-          <label>Date</label>
+          <label>Start Date</label>
           <input type="date" id="eventdate" />
         </div>
         <div class="cl-field">
-          <label>City</label>
-          <input type="text" id="eventcity" placeholder="e.g. Kuala Lumpur" />
+          <label>End Date</label>
+          <input type="date" id="eventenddate" />
         </div>
       </div>
 
       <div class="cl-row">
         <div class="cl-field">
+          <label>City</label>
+          <input type="text" id="eventcity" placeholder="e.g. Kuala Lumpur" />
+        </div>
+        <div class="cl-field">
           <label>Country</label>
           <input type="text" id="eventcountry" placeholder="e.g. Malaysia" />
         </div>
-        <div class="cl-field">
-          <label>Event Visibility</label>
-          <select id="eventpublic">
-            <option value="private">🔒 Private — invite only</option>
-            <option value="public">🌐 Public — listed on CloudLink</option>
-          </select>
-        </div>
+      </div>
+
+      <div class="cl-field">
+        <label>Event Visibility</label>
+        <select id="eventpublic">
+          <option value="private">🔒 Private — invite only</option>
+          <option value="public">🌐 Public — listed on CloudLink</option>
+        </select>
       </div>
 
       <div class="cl-field">
@@ -386,13 +391,12 @@
       <h2>Event Image</h2>
       <div class="cl-img-options">
 
-        <!-- Option 1: RH Logo -->
+        <!-- Option 1: Default logo -->
         <div class="cl-img-option selected" id="opt-rh_logo" onclick="selectImageMode('rh_logo')">
           <input type="radio" name="image_mode" value="rh_logo" checked>
           <div class="cl-img-option-body">
-            <div class="cl-img-option-label">Use RotorHazard Logo</div>
-            <div class="cl-img-option-desc">Uses the RotorHazard logo as the event image.</div>
-            <img src="/static/image/RotorHazard Logo.svg" class="cl-rh-logo-preview" alt="RotorHazard Logo">
+            <div class="cl-img-option-label">Use Default CloudLink Logo</div>
+            <div class="cl-img-option-desc">Uses the default CloudLink placeholder image. You can update it later.</div>
           </div>
         </div>
 
@@ -403,8 +407,8 @@
             <div class="cl-img-option-label">Upload a File</div>
             <div class="cl-img-option-desc">Upload a poster or chapter logo from this timer machine.</div>
             <div class="cl-img-option-input" id="upload-input">
-              <input type="file" id="image_file" class="cl-file-input" accept="image/jpeg,image/png,image/webp,image/svg+xml" onclick="event.stopPropagation()">
-              <div class="cl-file-hint">JPEG, PNG, WebP or SVG · Max 5 MB</div>
+              <input type="file" id="image_file" class="cl-file-input" accept="image/jpeg,image/png,image/webp" onclick="event.stopPropagation()">
+              <div class="cl-file-hint">JPEG, PNG or WebP · Max 5 MB</div>
             </div>
           </div>
         </div>
@@ -533,9 +537,12 @@
     setLoading(true);
 
     var formData = new FormData();
+    var startDate = document.getElementById('eventdate').value;
+    var endDate   = document.getElementById('eventenddate').value || startDate;
     formData.append('eventname',    eventname);
     formData.append('emailid',      emailid);
-    formData.append('eventdate',    document.getElementById('eventdate').value);
+    formData.append('eventdate',    startDate);
+    formData.append('eventenddate', endDate);
     formData.append('eventcity',    document.getElementById('eventcity').value.trim());
     formData.append('eventcountry', document.getElementById('eventcountry').value.trim());
     formData.append('eventdesc',    document.getElementById('eventdesc').value.trim());
@@ -590,7 +597,8 @@
     document.getElementById('register-form-section').style.display = 'block';
     document.getElementById('eventname').value = '';
     document.getElementById('emailid').value = '';
-    document.getElementById('eventdate').value = '';
+    document.getElementById('eventdate').value = today;
+    document.getElementById('eventenddate').value = today;
     document.getElementById('eventcity').value = '';
     document.getElementById('eventcountry').value = '';
     document.getElementById('eventpublic').value = 'private';
@@ -606,9 +614,10 @@
     });
   }
 
-  // Init: set default date to today
+  // Init: set default dates to today
   var today = new Date().toISOString().split('T')[0];
   document.getElementById('eventdate').value = today;
+  document.getElementById('eventenddate').value = today;
 </script>
 
 </body>

--- a/custom_plugins/cloudlink/templates/cloudlink/setup.html
+++ b/custom_plugins/cloudlink/templates/cloudlink/setup.html
@@ -330,6 +330,11 @@
         <input type="text" id="eventname" placeholder="e.g. UGKL Drone Race Round 3" />
       </div>
 
+      <div class="cl-field">
+        <label>Your Email *</label>
+        <input type="text" id="emailid" placeholder="e.g. racedirector@example.com" />
+      </div>
+
       <div class="cl-row">
         <div class="cl-field">
           <label>Date</label>
@@ -490,8 +495,13 @@
 
   function submitRegistration() {
     var eventname = document.getElementById('eventname').value.trim();
+    var emailid   = document.getElementById('emailid').value.trim();
     if (!eventname) {
       showStatus('Event name is required.', 'error');
+      return;
+    }
+    if (!emailid) {
+      showStatus('Email address is required.', 'error');
       return;
     }
 
@@ -500,6 +510,7 @@
 
     var formData = new FormData();
     formData.append('eventname',    eventname);
+    formData.append('emailid',      emailid);
     formData.append('eventdate',    document.getElementById('eventdate').value);
     formData.append('eventcity',    document.getElementById('eventcity').value.trim());
     formData.append('eventcountry', document.getElementById('eventcountry').value.trim());
@@ -553,6 +564,7 @@
     document.getElementById('success-state').style.display = 'none';
     document.getElementById('register-form-section').style.display = 'block';
     document.getElementById('eventname').value = '';
+    document.getElementById('emailid').value = '';
     document.getElementById('eventdate').value = '';
     document.getElementById('eventcity').value = '';
     document.getElementById('eventcountry').value = '';


### PR DESCRIPTION
Adds a full event registration UI embedded directly in the RotorHazard timer at `/cloudlink/setup`.

## What's in it
- **Flask Blueprint** at `/cloudlink/setup` — served by RH's own web server
- **Registration form** — event name, email, start/end date, city, country, visibility, description
- **Image upload** — default logo or upload from disk (JPEG/PNG/WebP)
- **Presigned S3 upload** — uses new `POST /uploads/presign` endpoint, direct PUT to S3
- **Keys auto-saved** — Event ID and Private Key written to RH options on success
- **Link from Format panel** — `Setup CloudLink Event` button in the existing panel

## Changes from old feature branch (#55)
- Replaced deprecated `/event/:id/upload-url` (410) with `/uploads/presign`
- Removed SVG from allowed upload types (presign endpoint only accepts jpeg/png/webp)
- Added `eventenddate` field (required by API)
- Default logo option no longer tries to upload the RH SVG logo