### PR TITLE
feat: in-timer event registration form

### DIFF
--- a/custom_plugins/cloudlink/__init__.py
+++ b/custom_plugins/cloudlink/__init__.py
@@ -13,3 +13,10 @@ def initialize(rhapi):
     rhapi.events.on(Evt.HEAT_DELETE, cloudlink.class_heat_delete)
     rhapi.events.on(Evt.CLASS_DELETE, cloudlink.class_heat_delete)
 
+    # Live telemetry hooks
+    rhapi.events.on(Evt.RACE_STAGE, cloudlink.live_race_stage)
+    rhapi.events.on(Evt.RACE_START, cloudlink.live_race_start)
+    rhapi.events.on(Evt.RACE_FINISH, cloudlink.live_race_finish)
+    rhapi.events.on(Evt.HEAT_SET, cloudlink.live_heat_set)
+    rhapi.events.on(Evt.LAP_RECORDED, cloudlink.live_lap_recorded)
+

--- a/custom_plugins/cloudlink/__init__.py
+++ b/custom_plugins/cloudlink/__init__.py
@@ -13,10 +13,3 @@ def initialize(rhapi):
     rhapi.events.on(Evt.HEAT_DELETE, cloudlink.class_heat_delete)
     rhapi.events.on(Evt.CLASS_DELETE, cloudlink.class_heat_delete)
 
-    # Live telemetry hooks
-    rhapi.events.on(Evt.RACE_STAGE, cloudlink.live_race_stage)
-    rhapi.events.on(Evt.RACE_START, cloudlink.live_race_start)
-    rhapi.events.on(Evt.RACE_FINISH, cloudlink.live_race_finish)
-    rhapi.events.on(Evt.HEAT_SET, cloudlink.live_heat_set)
-    rhapi.events.on(Evt.LAP_RECORDED, cloudlink.live_lap_recorded)
-

--- a/custom_plugins/cloudlink/cloudlink.py
+++ b/custom_plugins/cloudlink/cloudlink.py
@@ -194,12 +194,12 @@ class CloudLink():
 
             if slot.node_index is not None:
 
-                channel = racechannels[slot.node_index] 
+                channel = racechannels[slot.node_index] if slot.node_index < len(racechannels) else "0"
                 pilotcallsign = "-"
                 if slot.pilot_id != 0:
-                                        
                     pilot = db.pilot_by_id(slot.pilot_id)
-                    pilotcallsign = pilot.callsign
+                    if pilot is not None:
+                        pilotcallsign = pilot.callsign
                 thisslot = {
                     "nodeindex": slot.node_index,
                     "channel": channel,

--- a/custom_plugins/cloudlink/cloudlink.py
+++ b/custom_plugins/cloudlink/cloudlink.py
@@ -1,6 +1,8 @@
 import json
 import requests
 import logging
+import threading
+from datetime import datetime, timezone
 from sqlalchemy.ext.declarative import DeclarativeMeta
 from RHUI import UIField, UIFieldType, UIFieldSelectOption
 from .datamanager import ClDataManager
@@ -376,6 +378,123 @@ class CloudLink():
 
         else:
             self.logger.warning("No internet connection available")
+
+    # ── Live telemetry helpers ─────────────────────────────────────
+
+    def _post_async(self, endpoint, payload):
+        """Fire-and-forget POST in a background thread."""
+        def _do_post():
+            try:
+                requests.post(self.CL_API_ENDPOINT + endpoint, json=payload, timeout=5)
+            except Exception as e:
+                self.logger.warning("CloudLink live POST %s failed: %s", endpoint, e)
+        threading.Thread(target=_do_post, daemon=True).start()
+
+    def _live_guard(self):
+        """Return keys dict if live posting is allowed, else None."""
+        keys = self.getEventKeys()
+        if self.isEnabled() and keys["notempty"]:
+            return keys
+        return None
+
+    def _utcnow(self):
+        return datetime.now(timezone.utc).isoformat()
+
+    # ── Live race lifecycle ──────────────────────────────────────
+
+    def live_race_stage(self, args):
+        keys = self._live_guard()
+        if keys is None:
+            return
+        payload = {
+            "eventId": keys["eventid"],
+            "privateKey": keys["eventkey"],
+            "status": "armed",
+            "timestamp": self._utcnow()
+        }
+        self._post_async("/live/race", payload)
+        self.logger.info("Live telemetry: race armed")
+
+    def live_race_start(self, args):
+        keys = self._live_guard()
+        if keys is None:
+            return
+        payload = {
+            "eventId": keys["eventid"],
+            "privateKey": keys["eventkey"],
+            "status": "racing",
+            "timestamp": self._utcnow()
+        }
+        self._post_async("/live/race", payload)
+        self.logger.info("Live telemetry: race started")
+
+    def live_race_finish(self, args):
+        keys = self._live_guard()
+        if keys is None:
+            return
+        payload = {
+            "eventId": keys["eventid"],
+            "privateKey": keys["eventkey"],
+            "status": "finished",
+            "timestamp": self._utcnow()
+        }
+        self._post_async("/live/race", payload)
+        self.logger.info("Live telemetry: race finished")
+
+    # ── Live heat ────────────────────────────────────────────────
+
+    def live_heat_set(self, args):
+        keys = self._live_guard()
+        if keys is None:
+            return
+        db = self._rhapi.db
+        heat_id = args.get("heat_id")
+        if heat_id is None:
+            return
+        heat = db.heat_by_id(heat_id)
+        heat_name = heat.name if heat.name else "Heat " + str(heat_id)
+        slots = db.slots_by_heat(heat_id)
+        pilot_slots = []
+        for slot in slots:
+            if slot.node_index is not None and slot.pilot_id and slot.pilot_id != 0:
+                pilot = db.pilot_by_id(slot.pilot_id)
+                callsign = pilot.callsign if pilot else "-"
+                pilot_slots.append({
+                    "pilotId": slot.pilot_id,
+                    "callsign": callsign,
+                    "nodeIndex": slot.node_index
+                })
+        payload = {
+            "eventId": keys["eventid"],
+            "privateKey": keys["eventkey"],
+            "heatId": heat_id,
+            "heatName": heat_name,
+            "pilotSlots": pilot_slots,
+            "status": "set",
+            "timestamp": self._utcnow()
+        }
+        self._post_async("/live/heat", payload)
+        self.logger.info("Live telemetry: heat set — %s", heat_name)
+
+    # ── Live lap ─────────────────────────────────────────────────
+
+    def live_lap_recorded(self, args):
+        keys = self._live_guard()
+        if keys is None:
+            return
+        payload = {
+            "eventId": keys["eventid"],
+            "privateKey": keys["eventkey"],
+            "pilotId": args.get("pilot_id"),
+            "callsign": args.get("callsign", ""),
+            "nodeIndex": args.get("node_index"),
+            "lapNumber": args.get("lap_number"),
+            "lapTimeMs": args.get("lap_time"),
+            "lapTimeFormatted": args.get("lap_time_formatted", ""),
+            "isHoleshot": args.get("is_holeshot", False),
+            "timestamp": self._utcnow()
+        }
+        self._post_async("/live/lap", payload)
 
     def isConnected(self):
         try:

--- a/custom_plugins/cloudlink/cloudlink.py
+++ b/custom_plugins/cloudlink/cloudlink.py
@@ -49,7 +49,10 @@ class CloudLink():
         ui = self._rhapi.ui
         ui.register_panel("cloud-link", "Cloudlink", "format")
         ui.register_quickbutton("cloud-link", "send-all-button", "Resync", self.resync_new)
-        ui.register_quickbutton("cloud-link", "setup-button", "Setup / Register Event", self.open_setup)
+        ui.register_markdown("cloud-link", "cl-setup-link",
+            '<a href="/cloudlink/setup" class="button-like" style="display:inline-block;margin:4px 0;">'
+            '⚙ Setup / Register Event</a>'
+        )
 
         cl_enableplugin = UIField(name='cl-enable-plugin', label='Enable Cloud Link Plugin', field_type=UIFieldType.CHECKBOX, desc="Enable or disable this plugin.")
         cl_eventid  = UIField(name='cl-event-id',  label='Cloud Link Event ID',          field_type=UIFieldType.TEXT, desc="Event ID from rhcloudlink.com/register or the in-timer setup page.")
@@ -68,13 +71,6 @@ class CloudLink():
             self.logger.info("CloudLink: registration blueprint registered at /cloudlink/setup")
         except Exception as e:
             self.logger.error(f"CloudLink: failed to register blueprint: {e}")
-
-    def open_setup(self, args):
-        """Opens the in-timer registration UI in a new browser tab via JS redirect."""
-        self._rhapi.ui.message_notify(
-            'Opening CloudLink setup... <a href="/cloudlink/setup" target="_blank" '
-            'style="color:#ee7a28;font-weight:bold;">Click here if it did not open</a>'
-        )
 
     def resync_new(self, args):
      

--- a/custom_plugins/cloudlink/cloudlink.py
+++ b/custom_plugins/cloudlink/cloudlink.py
@@ -1,8 +1,6 @@
 import json
 import requests
 import logging
-import threading
-from datetime import datetime, timezone
 from sqlalchemy.ext.declarative import DeclarativeMeta
 from RHUI import UIField, UIFieldType, UIFieldSelectOption
 from .datamanager import ClDataManager
@@ -378,123 +376,6 @@ class CloudLink():
 
         else:
             self.logger.warning("No internet connection available")
-
-    # ── Live telemetry helpers ─────────────────────────────────────
-
-    def _post_async(self, endpoint, payload):
-        """Fire-and-forget POST in a background thread."""
-        def _do_post():
-            try:
-                requests.post(self.CL_API_ENDPOINT + endpoint, json=payload, timeout=5)
-            except Exception as e:
-                self.logger.warning("CloudLink live POST %s failed: %s", endpoint, e)
-        threading.Thread(target=_do_post, daemon=True).start()
-
-    def _live_guard(self):
-        """Return keys dict if live posting is allowed, else None."""
-        keys = self.getEventKeys()
-        if self.isEnabled() and keys["notempty"]:
-            return keys
-        return None
-
-    def _utcnow(self):
-        return datetime.now(timezone.utc).isoformat()
-
-    # ── Live race lifecycle ──────────────────────────────────────
-
-    def live_race_stage(self, args):
-        keys = self._live_guard()
-        if keys is None:
-            return
-        payload = {
-            "eventId": keys["eventid"],
-            "privateKey": keys["eventkey"],
-            "status": "armed",
-            "timestamp": self._utcnow()
-        }
-        self._post_async("/live/race", payload)
-        self.logger.info("Live telemetry: race armed")
-
-    def live_race_start(self, args):
-        keys = self._live_guard()
-        if keys is None:
-            return
-        payload = {
-            "eventId": keys["eventid"],
-            "privateKey": keys["eventkey"],
-            "status": "racing",
-            "timestamp": self._utcnow()
-        }
-        self._post_async("/live/race", payload)
-        self.logger.info("Live telemetry: race started")
-
-    def live_race_finish(self, args):
-        keys = self._live_guard()
-        if keys is None:
-            return
-        payload = {
-            "eventId": keys["eventid"],
-            "privateKey": keys["eventkey"],
-            "status": "finished",
-            "timestamp": self._utcnow()
-        }
-        self._post_async("/live/race", payload)
-        self.logger.info("Live telemetry: race finished")
-
-    # ── Live heat ────────────────────────────────────────────────
-
-    def live_heat_set(self, args):
-        keys = self._live_guard()
-        if keys is None:
-            return
-        db = self._rhapi.db
-        heat_id = args.get("heat_id")
-        if heat_id is None:
-            return
-        heat = db.heat_by_id(heat_id)
-        heat_name = heat.name if heat.name else "Heat " + str(heat_id)
-        slots = db.slots_by_heat(heat_id)
-        pilot_slots = []
-        for slot in slots:
-            if slot.node_index is not None and slot.pilot_id and slot.pilot_id != 0:
-                pilot = db.pilot_by_id(slot.pilot_id)
-                callsign = pilot.callsign if pilot else "-"
-                pilot_slots.append({
-                    "pilotId": slot.pilot_id,
-                    "callsign": callsign,
-                    "nodeIndex": slot.node_index
-                })
-        payload = {
-            "eventId": keys["eventid"],
-            "privateKey": keys["eventkey"],
-            "heatId": heat_id,
-            "heatName": heat_name,
-            "pilotSlots": pilot_slots,
-            "status": "set",
-            "timestamp": self._utcnow()
-        }
-        self._post_async("/live/heat", payload)
-        self.logger.info("Live telemetry: heat set — %s", heat_name)
-
-    # ── Live lap ─────────────────────────────────────────────────
-
-    def live_lap_recorded(self, args):
-        keys = self._live_guard()
-        if keys is None:
-            return
-        payload = {
-            "eventId": keys["eventid"],
-            "privateKey": keys["eventkey"],
-            "pilotId": args.get("pilot_id"),
-            "callsign": args.get("callsign", ""),
-            "nodeIndex": args.get("node_index"),
-            "lapNumber": args.get("lap_number"),
-            "lapTimeMs": args.get("lap_time"),
-            "lapTimeFormatted": args.get("lap_time_formatted", ""),
-            "isHoleshot": args.get("is_holeshot", False),
-            "timestamp": self._utcnow()
-        }
-        self._post_async("/live/lap", payload)
 
     def isConnected(self):
         try:

--- a/custom_plugins/cloudlink/cloudlink.py
+++ b/custom_plugins/cloudlink/cloudlink.py
@@ -2,7 +2,7 @@ import json
 import requests
 import logging
 from sqlalchemy.ext.declarative import DeclarativeMeta
-from RHUI import UIField, UIFieldType
+from RHUI import UIField, UIFieldType, UIFieldSelectOption
 from .datamanager import ClDataManager
 try:
     from .config import CL_API_ENDPOINT as _CONFIGURED_ENDPOINT
@@ -45,19 +45,36 @@ class CloudLink():
         
         self.init_ui(args)
         
-    def init_ui(self,args):
+    def init_ui(self, args):
         ui = self._rhapi.ui
         ui.register_panel("cloud-link", "Cloudlink", "format")
         ui.register_quickbutton("cloud-link", "send-all-button", "Resync", self.resync_new)
+        ui.register_quickbutton("cloud-link", "setup-button", "Setup / Register Event", self.open_setup)
 
-        cl_enableplugin = UIField(name = 'cl-enable-plugin', label = 'Enable Cloud Link Plugin', field_type = UIFieldType.CHECKBOX, desc = "Enable or disable this plugin. Unchecking this box will stop all communication with the Cloudlink server.")
-        cl_eventid = UIField(name = 'cl-event-id', label = 'Cloud Link Event ID', field_type = UIFieldType.TEXT, desc = "Event must be registered at rhcloudlink.com")
-        cl_eventkey = UIField(name = 'cl-event-key', label = 'Cloud Link Event Private Key', field_type = UIFieldType.TEXT, desc = "Authentication key provided by Cloudlink during event registration.")
+        cl_enableplugin = UIField(name='cl-enable-plugin', label='Enable Cloud Link Plugin', field_type=UIFieldType.CHECKBOX, desc="Enable or disable this plugin.")
+        cl_eventid  = UIField(name='cl-event-id',  label='Cloud Link Event ID',          field_type=UIFieldType.TEXT, desc="Event ID from rhcloudlink.com/register or the in-timer setup page.")
+        cl_eventkey = UIField(name='cl-event-key', label='Cloud Link Event Private Key', field_type=UIFieldType.TEXT, desc="Private key provided after registration. Keep this safe.")
 
         fields = self._rhapi.fields
         fields.register_option(cl_enableplugin, "cloud-link")
-        fields.register_option(cl_eventid, "cloud-link")
-        fields.register_option(cl_eventkey, "cloud-link")
+        fields.register_option(cl_eventid,      "cloud-link")
+        fields.register_option(cl_eventkey,     "cloud-link")
+
+        # Register the Flask blueprint for the in-timer registration UI
+        try:
+            from .registration_blueprint import create_registration_blueprint
+            bp = create_registration_blueprint(self._rhapi)
+            self._rhapi.ui.blueprint_add(bp)
+            self.logger.info("CloudLink: registration blueprint registered at /cloudlink/setup")
+        except Exception as e:
+            self.logger.error(f"CloudLink: failed to register blueprint: {e}")
+
+    def open_setup(self, args):
+        """Opens the in-timer registration UI in a new browser tab via JS redirect."""
+        self._rhapi.ui.message_notify(
+            'Opening CloudLink setup... <a href="/cloudlink/setup" target="_blank" '
+            'style="color:#ee7a28;font-weight:bold;">Click here if it did not open</a>'
+        )
 
     def resync_new(self, args):
      

--- a/custom_plugins/cloudlink/cloudlink.py
+++ b/custom_plugins/cloudlink/cloudlink.py
@@ -10,7 +10,7 @@ except ImportError:
     _CONFIGURED_ENDPOINT = "https://api.rhcloudlink.com"
 
 class CloudLink():
-    CL_VERSION = "1.2.1"
+    CL_VERSION = "1.5.0"
     CL_API_ENDPOINT = _CONFIGURED_ENDPOINT
     CL_FORCEUPDATE = False
 

--- a/custom_plugins/cloudlink/manifest.json
+++ b/custom_plugins/cloudlink/manifest.json
@@ -5,7 +5,7 @@
     "author_uri" : "https://github.com/vikibaarathi",
     "description" : "Instant pilot grouping, channel changes, ranking and tournament bracket visualization platform",
     "documentation_uri": "https://github.com/vikibaarathi/RHCloudlink-plugin/blob/main/README.md",
-    "version" : "1.4.1",
+    "version" : "1.5.0",
     "required_rhapi_version" : "1.2",
     "category": ["Event Management"]
 }

--- a/custom_plugins/cloudlink/manifest.json
+++ b/custom_plugins/cloudlink/manifest.json
@@ -5,7 +5,7 @@
     "author_uri" : "https://github.com/vikibaarathi",
     "description" : "Instant pilot grouping, channel changes, ranking and tournament bracket visualization platform",
     "documentation_uri": "https://github.com/vikibaarathi/RHCloudlink-plugin/blob/main/README.md",
-    "version" : "1.4.0",
+    "version" : "1.4.1",
     "required_rhapi_version" : "1.2",
     "category": ["Event Management"]
 }

--- a/custom_plugins/cloudlink/registration_blueprint.py
+++ b/custom_plugins/cloudlink/registration_blueprint.py
@@ -159,9 +159,9 @@ def create_registration_blueprint(rhapi):
                                 if patch_resp.status_code == 200:
                                     logger.info(f'[CloudLink] Image uploaded for {event_id}: {public_url}')
                                 else:
-                                    logger.warning(f'[CloudLink] PATCH failed ({patch_resp.status_code}) — event created, image not saved')
+                                    logger.warning(f'[CloudLink] Update failed ({patch_resp.status_code}) — event created, image not saved')
                             else:
-                                logger.warning(f'[CloudLink] S3 PUT failed ({s3_resp.status_code}) — event created, no image')
+                                logger.warning(f'[CloudLink] Cloud storage save failed ({s3_resp.status_code}) — event created, no image')
                         else:
                             logger.warning('[CloudLink] Missing uploadUrl/publicUrl in presign response')
                     else:

--- a/custom_plugins/cloudlink/registration_blueprint.py
+++ b/custom_plugins/cloudlink/registration_blueprint.py
@@ -183,6 +183,119 @@ def create_registration_blueprint(rhapi):
             return jsonify({'success': False, 'error': str(e)}), 500
 
     # ──────────────────────────────────────────────────────────────────────────
+    # GET /cloudlink/event-details — proxy to fetch event details from API
+    # ──────────────────────────────────────────────────────────────────────────
+    @bp.route('/event-details', methods=['GET'])
+    def event_details():
+        try:
+            event_id = request.args.get('eventid', '').strip()
+            if not event_id:
+                return jsonify({'success': False, 'error': 'eventid required'}), 400
+
+            resp = requests.get(
+                f'{CL_API_ENDPOINT}/event',
+                params={'eventid': event_id},
+                timeout=API_TIMEOUT_SHORT
+            )
+            if resp.status_code != 200:
+                return jsonify({'success': False, 'error': f'API error ({resp.status_code})'}), 502
+
+            data = resp.json()
+            logger.info(f'[CloudLink] event-details raw response type={type(data).__name__}: {str(data)[:200]}')
+
+            # API returns a list of items, or a string error message
+            event = None
+            if isinstance(data, list):
+                for item in data:
+                    if isinstance(item, dict) and item.get('sk', '').startswith('event'):
+                        event = item
+                        break
+                if not event and data:
+                    # fallback: take first dict item
+                    event = next((i for i in data if isinstance(i, dict)), None)
+
+            if not event:
+                return jsonify({'success': False, 'error': 'Event not found'}), 404
+
+            return jsonify({'success': True, 'event': event})
+
+        except Exception as e:
+            logger.error(f'[CloudLink] Event details error: {e}', exc_info=True)
+            return jsonify({'success': False, 'error': str(e)}), 500
+
+    # ──────────────────────────────────────────────────────────────────────────
+    # POST /cloudlink/upload-logo — upload/replace logo for an existing event
+    # ──────────────────────────────────────────────────────────────────────────
+    @bp.route('/upload-logo', methods=['POST'])
+    def upload_logo():
+        try:
+            event_id = (request.form.get('eventid',  '') or '').strip()
+            priv_key = (request.form.get('eventkey', '') or '').strip()
+            image_file = request.files.get('image_file')
+
+            if not event_id or not priv_key:
+                return jsonify({'success': False, 'error': 'Event ID and private key are required'}), 400
+            if not image_file or not image_file.filename:
+                return jsonify({'success': False, 'error': 'No image file provided'}), 400
+
+            content_type = image_file.content_type or 'image/jpeg'
+            if content_type not in ALLOWED_IMAGE_TYPES:
+                return jsonify({'success': False, 'error': 'Only JPEG, PNG or WebP images are allowed'}), 400
+
+            file_bytes = image_file.read()
+            if len(file_bytes) > 5 * 1024 * 1024:
+                return jsonify({'success': False, 'error': 'Image must be under 5MB'}), 400
+
+            file_name = image_file.filename or 'image.jpg'
+
+            # Step 1: Get presigned URL
+            presign_resp = requests.post(
+                f'{CL_API_ENDPOINT}/uploads/presign',
+                json={'fileName': file_name, 'contentType': content_type},
+                timeout=API_TIMEOUT_SHORT
+            )
+            if presign_resp.status_code != 200:
+                return jsonify({'success': False, 'error': f'Presign failed ({presign_resp.status_code})'}), 502
+
+            presign_data = presign_resp.json().get('data', {})
+            upload_url   = presign_data.get('uploadUrl')
+            public_url   = presign_data.get('publicUrl')
+
+            if not upload_url or not public_url:
+                return jsonify({'success': False, 'error': 'Invalid presign response'}), 502
+
+            # Step 2: PUT image to S3
+            s3_resp = requests.put(
+                upload_url,
+                data=file_bytes,
+                headers={'Content-Type': content_type},
+                timeout=API_TIMEOUT_S3
+            )
+            if s3_resp.status_code not in (200, 204):
+                return jsonify({'success': False, 'error': f'S3 upload failed ({s3_resp.status_code})'}), 502
+
+            # Step 3: PATCH event with new logo URL
+            patch_resp = requests.patch(
+                f'{CL_API_ENDPOINT}/event/{event_id}',
+                json={'eventlogourl': public_url},
+                headers={'X-Private-Key': priv_key},
+                timeout=API_TIMEOUT_SHORT
+            )
+            if patch_resp.status_code != 200:
+                return jsonify({'success': False, 'error': f'Event update failed ({patch_resp.status_code})'}), 502
+
+            logger.info(f'[CloudLink] Logo updated for event {event_id}: {public_url}')
+            return jsonify({'success': True, 'logourl': public_url})
+
+        except requests.exceptions.ConnectionError:
+            return jsonify({'success': False, 'error': 'Cannot reach CloudLink API — check internet connection'}), 503
+        except requests.exceptions.Timeout:
+            return jsonify({'success': False, 'error': 'CloudLink API timed out — please try again'}), 504
+        except Exception as e:
+            logger.error(f'[CloudLink] Upload logo error: {e}', exc_info=True)
+            return jsonify({'success': False, 'error': str(e)}), 500
+
+    # ──────────────────────────────────────────────────────────────────────────
     # POST /cloudlink/clear — reset saved keys
     # ──────────────────────────────────────────────────────────────────────────
     @bp.route('/clear', methods=['POST'])

--- a/custom_plugins/cloudlink/registration_blueprint.py
+++ b/custom_plugins/cloudlink/registration_blueprint.py
@@ -1,0 +1,195 @@
+"""
+CloudLink Registration Blueprint
+Serves the in-timer event registration UI at /cloudlink/setup.
+
+Flow (mirrors the Angular registration form exactly):
+  1. POST /register           → get eventid + privatekey
+  2. POST /uploads/presign    → get uploadUrl + publicUrl
+  3. PUT  {uploadUrl}         → upload image bytes direct to S3 (no auth needed)
+  4. PATCH /event/{id}        → save eventlogourl (X-Private-Key header)
+  5. Save eventid + privatekey to RH options
+
+CORS note: The CloudLink API uses Access-Control-Allow-Origin: *
+and S3 bucket CORS also allows all origins — so timer machines
+without a domain/IP address can call these endpoints freely.
+"""
+
+import os
+import logging
+import requests
+from flask import Blueprint, render_template, request, jsonify
+
+logger = logging.getLogger(__name__)
+
+API_TIMEOUT_SHORT = 10   # seconds — for API calls
+API_TIMEOUT_S3    = 30   # seconds — for S3 PUT (file upload)
+
+ALLOWED_IMAGE_TYPES = {'image/jpeg', 'image/png', 'image/webp'}
+
+
+def create_registration_blueprint(rhapi):
+    """
+    Factory — creates and returns the Flask Blueprint.
+    Pass rhapi so the blueprint can read/write RH options.
+    """
+
+    try:
+        from .config import CL_API_ENDPOINT
+    except ImportError:
+        CL_API_ENDPOINT = 'https://api.rhcloudlink.com'
+
+    bp = Blueprint(
+        'cloudlink_registration',
+        __name__,
+        template_folder=os.path.join(os.path.dirname(__file__), 'templates'),
+        url_prefix='/cloudlink'
+    )
+
+    # ──────────────────────────────────────────────────────────────────────────
+    # GET /cloudlink/setup — render the registration page
+    # ──────────────────────────────────────────────────────────────────────────
+    @bp.route('/setup')
+    def setup():
+        eventid  = rhapi.db.option('cl-event-id')  or ''
+        eventkey = rhapi.db.option('cl-event-key') or ''
+        return render_template('cloudlink/setup.html',
+                               eventid=eventid,
+                               eventkey=eventkey)
+
+    # ──────────────────────────────────────────────────────────────────────────
+    # POST /cloudlink/register — full registration flow
+    # ──────────────────────────────────────────────────────────────────────────
+    @bp.route('/register', methods=['POST'])
+    def register():
+        try:
+            # ── Read form fields ────────────────────────────────────────────
+            event_name     = (request.form.get('eventname',    '') or '').strip()
+            email_id       = (request.form.get('emailid',      '') or '').strip()
+            event_date     = (request.form.get('eventdate',    '') or '').strip()
+            event_end_date = (request.form.get('eventenddate', '') or '').strip() or event_date
+            event_city     = (request.form.get('eventcity',    '') or '').strip()
+            event_country  = (request.form.get('eventcountry', '') or '').strip()
+            event_desc     = (request.form.get('eventdesc',    '') or '').strip()
+            event_public   = (request.form.get('eventpublic',  'private') or 'private').strip()
+            has_image      = request.form.get('has_image', 'false') == 'true'
+
+            if event_public not in ('public', 'private'):
+                event_public = 'private'
+
+            if not event_name:
+                return jsonify({'success': False, 'error': 'Event name is required'}), 400
+            if not email_id:
+                return jsonify({'success': False, 'error': 'Email address is required'}), 400
+
+            # ── Step 1: Register the event ──────────────────────────────────
+            reg_payload = {
+                'emailid':      email_id,
+                'eventname':    event_name,
+                'eventdate':    event_date,
+                'eventenddate': event_end_date,
+                'eventcity':    event_city,
+                'eventcountry': event_country,
+                'eventdesc':    event_desc,
+                'eventpublic':  event_public,
+                'eventtype':    'T',
+            }
+
+            reg_resp = requests.post(
+                f'{CL_API_ENDPOINT}/register',
+                json=reg_payload,
+                timeout=API_TIMEOUT_SHORT
+            )
+
+            if reg_resp.status_code != 200:
+                logger.error(f'[CloudLink] Registration failed: {reg_resp.status_code} {reg_resp.text}')
+                return jsonify({'success': False, 'error': f'Registration failed ({reg_resp.status_code})'}), 502
+
+            reg_data  = reg_resp.json()
+            event_id  = reg_data.get('eventid')
+            priv_key  = reg_data.get('privatekey')
+
+            if not event_id or not priv_key:
+                logger.error(f'[CloudLink] Missing keys in registration response: {reg_data}')
+                return jsonify({'success': False, 'error': 'Invalid response from CloudLink API'}), 502
+
+            logger.info(f'[CloudLink] Event registered: {event_id}')
+
+            # ── Step 2 + 3 + 4: Image upload (if file provided) ────────────
+            # Mirrors Angular: presign → PUT to S3 → PATCH event
+            image_file = request.files.get('image_file') if has_image else None
+
+            if image_file and image_file.filename:
+                content_type = image_file.content_type or 'image/jpeg'
+
+                if content_type not in ALLOWED_IMAGE_TYPES:
+                    logger.warning(f'[CloudLink] Unsupported image type {content_type} — skipping upload')
+                else:
+                    file_bytes = image_file.read()
+                    file_name  = image_file.filename or 'image.jpg'
+
+                    # Step 2: Get presigned URL
+                    presign_resp = requests.post(
+                        f'{CL_API_ENDPOINT}/uploads/presign',
+                        json={'fileName': file_name, 'contentType': content_type},
+                        timeout=API_TIMEOUT_SHORT
+                    )
+
+                    if presign_resp.status_code == 200:
+                        presign_data = presign_resp.json().get('data', {})
+                        upload_url   = presign_data.get('uploadUrl')
+                        public_url   = presign_data.get('publicUrl')
+
+                        if upload_url and public_url:
+                            # Step 3: PUT image direct to S3
+                            s3_resp = requests.put(
+                                upload_url,
+                                data=file_bytes,
+                                headers={'Content-Type': content_type},
+                                timeout=API_TIMEOUT_S3
+                            )
+
+                            if s3_resp.status_code in (200, 204):
+                                # Step 4: PATCH event with image URL
+                                patch_resp = requests.patch(
+                                    f'{CL_API_ENDPOINT}/event/{event_id}',
+                                    json={'eventlogourl': public_url},
+                                    headers={'X-Private-Key': priv_key},
+                                    timeout=API_TIMEOUT_SHORT
+                                )
+                                if patch_resp.status_code == 200:
+                                    logger.info(f'[CloudLink] Image uploaded for {event_id}: {public_url}')
+                                else:
+                                    logger.warning(f'[CloudLink] PATCH failed ({patch_resp.status_code}) — event created, image not saved')
+                            else:
+                                logger.warning(f'[CloudLink] S3 PUT failed ({s3_resp.status_code}) — event created, no image')
+                        else:
+                            logger.warning('[CloudLink] Missing uploadUrl/publicUrl in presign response')
+                    else:
+                        logger.warning(f'[CloudLink] Presign failed ({presign_resp.status_code}) — event created, no image')
+
+            # ── Step 5: Save keys to RH ─────────────────────────────────────
+            rhapi.db.option_set('cl-event-id',  event_id)
+            rhapi.db.option_set('cl-event-key', priv_key)
+            logger.info(f'[CloudLink] Keys saved to RH for event {event_id}')
+
+            return jsonify({'success': True, 'eventid': event_id, 'privatekey': priv_key})
+
+        except requests.exceptions.ConnectionError:
+            return jsonify({'success': False, 'error': 'Cannot reach CloudLink API — check internet connection'}), 503
+        except requests.exceptions.Timeout:
+            return jsonify({'success': False, 'error': 'CloudLink API timed out — please try again'}), 504
+        except Exception as e:
+            logger.error(f'[CloudLink] Registration error: {e}', exc_info=True)
+            return jsonify({'success': False, 'error': str(e)}), 500
+
+    # ──────────────────────────────────────────────────────────────────────────
+    # POST /cloudlink/clear — reset saved keys
+    # ──────────────────────────────────────────────────────────────────────────
+    @bp.route('/clear', methods=['POST'])
+    def clear():
+        rhapi.db.option_set('cl-event-id',  '')
+        rhapi.db.option_set('cl-event-key', '')
+        logger.info('[CloudLink] Keys cleared')
+        return jsonify({'success': True})
+
+    return bp

--- a/custom_plugins/cloudlink/templates/cloudlink/setup.html
+++ b/custom_plugins/cloudlink/templates/cloudlink/setup.html
@@ -299,47 +299,56 @@
     <div id="form-section" {% if eventid and eventkey %}style="display:none"{% endif %}>
 
       <h5 class="mb-3">Event Details</h5>
-      <div class="mb-3">
-        <label class="form-label" for="eventname">Event Name <span class="text-danger">*</span></label>
-        <input type="text" class="form-control" id="eventname" placeholder="e.g. UGKL FPV Round 3" maxlength="100">
-      </div>
-      <div class="mb-3">
-        <label class="form-label" for="emailid">Race Director Email <span class="text-danger">*</span></label>
-        <input type="text" class="form-control" id="emailid" placeholder="e.g. director@example.com" maxlength="254">
-      </div>
-      <div class="row g-3 mb-3">
-        <div class="col-6">
-          <label class="form-label" for="eventdate">Start Date</label>
-          <input type="date" class="form-control" id="eventdate">
-        </div>
-        <div class="col-6">
-          <label class="form-label" for="eventenddate">End Date</label>
-          <input type="date" class="form-control" id="eventenddate">
-        </div>
-      </div>
-      <div class="row g-3 mb-3">
-        <div class="col-6">
-          <label class="form-label" for="eventcity">City</label>
-          <input type="text" class="form-control" id="eventcity" placeholder="e.g. Kuala Lumpur" maxlength="100">
-        </div>
-        <div class="col-6">
-          <label class="form-label" for="eventcountry">Country</label>
-          <input type="text" class="form-control" id="eventcountry" placeholder="e.g. Malaysia" maxlength="100">
-        </div>
-      </div>
-      <div class="mb-3">
-        <label class="form-label" for="eventpublic">Visibility</label>
-        <select class="form-select" id="eventpublic">
-          <option value="private">Private — not listed publicly</option>
-          <option value="public">Public — shown on Cloudlink events page</option>
-        </select>
-      </div>
-      <div class="mb-3">
-        <label class="form-label" for="eventdesc">Description</label>
-        <textarea class="form-control" id="eventdesc" rows="3" placeholder="Brief description of the event..." maxlength="500"></textarea>
-      </div>
 
-      <h5 class="mb-2 mt-4">Event Logo <small class="text-muted fw-normal" style="font-size:0.75em;">optional — JPEG, PNG or WebP, max 5MB</small></h5>
+      <div class="row g-4">
+
+        <!-- ── Left column ── -->
+        <div class="col-12 col-md-6">
+          <div class="mb-3">
+            <label class="form-label" for="eventname">Event Name <span class="text-danger">*</span></label>
+            <input type="text" class="form-control" id="eventname" placeholder="e.g. UGKL FPV Round 3" maxlength="100">
+          </div>
+          <div class="mb-3">
+            <label class="form-label" for="emailid">Race Director Email <span class="text-danger">*</span></label>
+            <input type="text" class="form-control" id="emailid" placeholder="e.g. director@example.com" maxlength="254">
+          </div>
+          <div class="mb-3">
+            <label class="form-label" for="eventdate">Start Date</label>
+            <input type="date" class="form-control" id="eventdate">
+          </div>
+          <div class="mb-3">
+            <label class="form-label" for="eventenddate">End Date</label>
+            <input type="date" class="form-control" id="eventenddate">
+          </div>
+        </div>
+
+        <!-- ── Right column ── -->
+        <div class="col-12 col-md-6">
+          <div class="mb-3">
+            <label class="form-label" for="eventcity">City</label>
+            <input type="text" class="form-control" id="eventcity" placeholder="e.g. Kuala Lumpur" maxlength="100">
+          </div>
+          <div class="mb-3">
+            <label class="form-label" for="eventcountry">Country</label>
+            <input type="text" class="form-control" id="eventcountry" placeholder="e.g. Malaysia" maxlength="100">
+          </div>
+          <div class="mb-3">
+            <label class="form-label" for="eventpublic">Visibility</label>
+            <select class="form-select" id="eventpublic">
+              <option value="private">Private — not listed publicly</option>
+              <option value="public">Public — shown on Cloudlink events page</option>
+            </select>
+          </div>
+          <div class="mb-3">
+            <label class="form-label" for="eventdesc">Description</label>
+            <textarea class="form-control" id="eventdesc" rows="3" placeholder="Brief description of the event..." maxlength="500"></textarea>
+          </div>
+        </div>
+
+      </div><!-- /row -->
+
+      <!-- ── Logo — full width ── -->
+      <h5 class="mb-2 mt-2">Event Logo <small class="text-muted fw-normal" style="font-size:0.75em;">optional — JPEG, PNG or WebP, max 5MB</small></h5>
       <div class="cl-dropzone mb-1" id="dropzone"
            ondragover="onDragOver(event)" ondragleave="onDragLeave()" ondrop="onDrop(event)"
            onclick="onDropzoneClick()">

--- a/custom_plugins/cloudlink/templates/cloudlink/setup.html
+++ b/custom_plugins/cloudlink/templates/cloudlink/setup.html
@@ -2,320 +2,276 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>CloudLink — Event Setup</title>
   <link rel="stylesheet" href="/static/rotorhazard.css">
+  <link rel="apple-touch-icon" sizes="180x180" href="/static/image/apple-touch-icon.png">
   <link rel="icon" type="image/png" sizes="32x32" href="/static/image/favicon-32x32.png">
   <style>
-    body { padding: 0; margin: 0; }
+    /* Only additions — everything else inherits from rotorhazard.css */
 
-    /* Header */
-    .cl-header {
+    .cl-page-wrap {
+      max-width: 41em;
+      margin: 0 auto;
+      padding: 1em 1em 4em;
+    }
+
+    /* Back link row */
+    .cl-topbar {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      margin-bottom: 1.5em;
+    }
+
+    /* Drop zone — only custom element */
+    .cl-dropzone {
+      border: 2px dashed hsl(var(--hue_0), var(--sat_0), var(--lum_0_low));
+      border-radius: 0.25rem;
+      min-height: 90px;
       display: flex;
       align-items: center;
-      justify-content: space-between;
-      padding: 14px 24px;
-      border-bottom: 2px solid var(--color-interface-border, #2a4a6b);
-      background: var(--color-panel-bg, #1a3550);
-    }
-    .cl-header h1 { font-size: 1.2rem; margin: 0; color: #fff; }
-    .cl-badge {
-      font-size: 0.6rem; background: #ee7a28; color: #fff;
-      border-radius: 4px; padding: 2px 6px; font-weight: 700;
-      text-transform: uppercase; margin-left: 8px; vertical-align: middle;
-    }
-    .cl-back { font-size: 0.85rem; color: #ee7a28; text-decoration: none; }
-    .cl-back:hover { text-decoration: underline; }
-
-    /* Layout */
-    .cl-container { max-width: 660px; margin: 28px auto; padding: 0 20px 60px; }
-
-    /* Card */
-    .cl-card {
-      background: var(--color-panel-bg, #1e3d5c);
-      border: 1px solid var(--color-interface-border, #2a4a6b);
-      border-radius: 6px; padding: 22px; margin-bottom: 16px;
-    }
-    .cl-card-title {
-      font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.08em;
-      color: #ee7a28; margin: 0 0 16px; font-weight: 700;
-    }
-
-    /* Fields */
-    .cl-field { margin-bottom: 14px; }
-    .cl-field label {
-      display: block; font-size: 0.75rem; color: var(--color-text-secondary, #9ab);
-      margin-bottom: 4px; text-transform: uppercase; letter-spacing: 0.04em;
-    }
-    .cl-field input, .cl-field select, .cl-field textarea {
-      width: 100%; box-sizing: border-box;
-      background: var(--color-input-bg, #132d45);
-      border: 1px solid var(--color-interface-border, #2a4a6b);
-      border-radius: 4px; color: var(--color-text, #dde);
-      padding: 8px 11px; font-size: 0.9rem; font-family: inherit;
-      outline: none; transition: border-color 0.15s;
-    }
-    .cl-field input:focus, .cl-field textarea:focus, .cl-field select:focus { border-color: #ee7a28; }
-    .cl-field textarea { resize: vertical; min-height: 70px; }
-    .cl-field select { cursor: pointer; appearance: none; }
-    .cl-row { display: flex; gap: 14px; }
-    .cl-row .cl-field { flex: 1; }
-
-    /* Drop zone */
-    .cl-dropzone {
-      border: 2px dashed var(--color-interface-border, #2a4a6b);
-      border-radius: 6px; min-height: 100px;
-      display: flex; align-items: center; justify-content: center;
-      cursor: pointer; transition: border-color 0.15s, background 0.15s;
-      position: relative; overflow: hidden;
-      background: var(--color-input-bg, #132d45);
+      justify-content: center;
+      cursor: pointer;
+      transition: border-color 0.15s, background 0.15s;
+      position: relative;
+      overflow: hidden;
+      width: 100%;
+      box-sizing: border-box;
     }
     .cl-dropzone:hover, .cl-dropzone.drag-over {
-      border-color: #ee7a28; background: rgba(238,122,40,0.05);
+      border-color: hsl(var(--hue_1), var(--sat_1), var(--lum_1_high));
     }
-    .cl-dropzone.has-image { cursor: default; border-style: solid; border-color: #ee7a28; }
-    .cl-dropzone-empty { text-align: center; padding: 20px; pointer-events: none; }
-    .cl-dropzone-icon { font-size: 1.8rem; display: block; margin-bottom: 6px; opacity: 0.5; }
-    .cl-dropzone-text { font-size: 0.85rem; color: var(--color-text-secondary, #9ab); margin: 0; }
-    .cl-dropzone-link { color: #ee7a28; text-decoration: underline; }
-    .cl-dropzone-hint { font-size: 0.72rem; color: var(--color-text-secondary, #9ab); margin-top: 4px; }
-    .cl-dropzone-preview { width: 100%; height: 110px; position: relative; }
-    .cl-preview-img { width: 100%; height: 100%; object-fit: cover; display: block; }
+    .cl-dropzone.has-image {
+      cursor: default;
+      border-style: solid;
+    }
+    .cl-dropzone-empty {
+      text-align: center;
+      padding: 16px;
+      pointer-events: none;
+      font-style: italic;
+      opacity: 0.7;
+      font-size: 0.85em;
+    }
+    .cl-dropzone-preview {
+      width: 100%;
+      height: 100px;
+      position: relative;
+    }
+    .cl-preview-img {
+      width: 100%; height: 100%;
+      object-fit: cover; display: block;
+    }
     .cl-preview-remove {
-      position: absolute; top: 6px; right: 6px;
-      background: rgba(200,60,60,0.85); color: #fff;
-      border: none; border-radius: 50%; width: 24px; height: 24px;
-      font-size: 0.8rem; cursor: pointer; display: flex;
-      align-items: center; justify-content: center;
+      position: absolute; top: 4px; right: 4px;
+      background: rgba(180,40,40,0.85); color: #fff;
+      border: none; border-radius: 0.25rem;
+      padding: 2px 8px; cursor: pointer; font-size: 0.8em;
     }
-    .cl-upload-error { font-size: 0.78rem; color: #f88; margin-top: 6px; display: none; }
-    .cl-upload-status { font-size: 0.78rem; color: var(--color-text-secondary, #9ab); margin-top: 6px; display: none; }
-
-    /* Buttons */
-    .cl-btn {
-      display: inline-flex; align-items: center; gap: 7px;
-      padding: 9px 22px; border-radius: 4px; font-size: 0.9rem;
-      font-weight: 600; cursor: pointer; border: none;
-      font-family: inherit; letter-spacing: 0.02em; transition: opacity 0.15s;
+    .cl-upload-error {
+      color: hsl(8.2, 86.5%, 53.7%);
+      font-size: 0.8em; margin-top: 4px; display: none;
     }
-    .cl-btn-primary { background: #ee7a28; color: #fff; }
-    .cl-btn-primary:hover { opacity: 0.87; }
-    .cl-btn-primary:disabled { opacity: 0.4; cursor: not-allowed; }
-    .cl-btn-secondary { background: transparent; color: #ee7a28; border: 1px solid #ee7a28; }
-    .cl-btn-secondary:hover { background: rgba(238,122,40,0.1); }
-    .cl-btn-row { display: flex; gap: 10px; align-items: center; flex-wrap: wrap; }
 
-    /* Spinner */
-    .cl-spinner {
-      width: 14px; height: 14px; border: 2px solid rgba(255,255,255,0.25);
-      border-top-color: #fff; border-radius: 50%;
-      animation: spin 0.65s linear infinite; display: none;
+    /* Key display box */
+    .cl-key-wrap {
+      display: flex; gap: 0.5em; align-items: center; margin-top: 0.25em;
     }
-    .submitting .cl-spinner { display: block; }
-    .submitting .cl-btn-label { opacity: 0.7; }
-    @keyframes spin { to { transform: rotate(360deg); } }
-
-    /* Status */
-    .cl-status {
-      font-size: 0.82rem; padding: 9px 13px; border-radius: 4px;
-      margin-top: 12px; display: none;
-    }
-    .cl-status.error { background: rgba(200,60,60,0.15); border: 1px solid rgba(200,60,60,0.35); color: #f88; }
-    .cl-status.info  { background: rgba(238,122,40,0.1);  border: 1px solid rgba(238,122,40,0.3);  color: #ee7a28; }
-
-    /* Existing keys */
-    .cl-key-row { display: flex; align-items: center; gap: 8px; margin-top: 6px; }
     .cl-key-box {
-      flex: 1; background: var(--color-input-bg, #132d45);
-      border: 1px solid var(--color-interface-border, #2a4a6b);
-      border-radius: 4px; padding: 7px 11px;
-      font-family: monospace; font-size: 0.95rem; color: #ee7a28; letter-spacing: 0.05em;
+      flex: 1;
+      border: solid 0.125em hsl(var(--hue_0), var(--sat_0), var(--lum_0_low));
+      border-radius: 0.25rem;
+      padding: 0.25rem 0.5rem;
+      font-family: monospace;
+      font-size: 1em;
+      background: #fff;
+      color: #000;
+      word-break: break-all;
     }
-    .cl-copy-btn {
-      background: none; border: 1px solid var(--color-interface-border, #2a4a6b);
-      border-radius: 4px; color: var(--color-text-secondary, #9ab);
-      padding: 6px 10px; cursor: pointer; font-size: 0.72rem; white-space: nowrap;
+    @media (prefers-color-scheme: dark) {
+      .cl-key-box { background: #000; color: #fff; }
     }
-    .cl-copy-btn:hover { border-color: #ee7a28; color: #ee7a28; }
 
-    /* Success */
-    #success-section { display: none; }
-    .cl-success-icon { font-size: 2.2rem; text-align: center; margin-bottom: 10px; }
-    .cl-success-msg {
-      text-align: center; font-size: 0.88rem;
-      color: var(--color-text-secondary, #9ab); margin-bottom: 20px; line-height: 1.5;
+    /* Spinner inside button */
+    .cl-spinner {
+      display: none;
+      width: 0.9em; height: 0.9em;
+      border: 2px solid rgba(255,255,255,0.3);
+      border-top-color: #fff;
+      border-radius: 50%;
+      animation: cl-spin 0.65s linear infinite;
+      vertical-align: middle;
+      margin-right: 0.3em;
     }
-    .cl-success-msg strong { color: var(--color-text, #dde); }
+    .cl-loading .cl-spinner { display: inline-block; }
+    @keyframes cl-spin { to { transform: rotate(360deg); } }
+
+    /* Success icon */
+    .cl-success-icon { font-size: 2em; text-align: center; padding: 0.5em 0; }
+
+    /* Row layout for paired fields */
+    .cl-field-row { display: flex; gap: 1em; }
+    .cl-field-row > * { flex: 1; }
+
+    ol.form > li > .cl-dropzone { flex: 1 1 0; margin-left: 0.5em; }
   </style>
 </head>
 <body>
 
-<div class="cl-header">
-  <h1>CloudLink <span class="cl-badge">Event Setup</span></h1>
-  <a class="cl-back" href="/format">← Back to Format</a>
-</div>
+<div class="cl-page-wrap">
 
-<div class="cl-container">
+  <div class="cl-topbar">
+    <h3 style="margin:0;">CloudLink — Event Setup</h3>
+    <a href="/format" class="button-like">← Back to Format</a>
+  </div>
 
   <!-- ── Already registered ── -->
   {% if eventid and eventkey %}
-  <div class="cl-card" id="existing-section">
-    <div class="cl-card-title">✅ Event Registered</div>
-    <div class="cl-field">
-      <label>Event ID</label>
-      <div class="cl-key-row">
-        <div class="cl-key-box">{{ eventid }}</div>
-        <button class="cl-copy-btn" onclick="copyText('{{ eventid }}', this)">Copy</button>
-      </div>
-    </div>
-    <div class="cl-field">
-      <label>Private Key</label>
-      <div class="cl-key-row">
-        <div class="cl-key-box">{{ eventkey }}</div>
-        <button class="cl-copy-btn" onclick="copyText('{{ eventkey }}', this)">Copy</button>
-      </div>
-    </div>
-    <div class="cl-btn-row" style="margin-top:18px;">
-      <a class="cl-btn cl-btn-primary" href="/format">Done — Back to Format</a>
-      <button class="cl-btn cl-btn-secondary" onclick="showForm()">Register a Different Event</button>
-    </div>
+  <div id="existing-section">
+    <h4>✅ Event Registered</h4>
+    <ol class="form">
+      <li>
+        <div class="label-block"><label>Event ID</label></div>
+        <div class="cl-key-wrap">
+          <div class="cl-key-box">{{ eventid }}</div>
+          <button type="button" onclick="copyText('{{ eventid }}', this)">Copy</button>
+        </div>
+      </li>
+      <li>
+        <div class="label-block"><label>Private Key</label></div>
+        <div class="cl-key-wrap">
+          <div class="cl-key-box">{{ eventkey }}</div>
+          <button type="button" onclick="copyText('{{ eventkey }}', this)">Copy</button>
+        </div>
+      </li>
+      <li>
+        <div class="label-block"></div>
+        <div>
+          <a href="/format" class="button-like">Done — Back to Format</a>
+          &nbsp;
+          <button type="button" onclick="showForm()">Register a Different Event</button>
+        </div>
+      </li>
+    </ol>
   </div>
   {% endif %}
 
   <!-- ── Registration form ── -->
   <div id="form-section" {% if eventid and eventkey %}style="display:none"{% endif %}>
 
-    <!-- Event Details -->
-    <div class="cl-card">
-      <div class="cl-card-title">Event Details</div>
-
-      <div class="cl-field">
-        <label>Event Name *</label>
+    <h2>Event Details</h2>
+    <ol class="form">
+      <li>
+        <div class="label-block"><label for="eventname">Event Name *</label></div>
         <input type="text" id="eventname" placeholder="e.g. UGKL FPV Round 3" maxlength="100">
-      </div>
-
-      <div class="cl-field">
-        <label>Race Director Email *</label>
+      </li>
+      <li>
+        <div class="label-block"><label for="emailid">Race Director Email *</label></div>
         <input type="text" id="emailid" placeholder="e.g. director@example.com" maxlength="254">
-      </div>
-
-      <div class="cl-row">
-        <div class="cl-field">
-          <label>Start Date</label>
-          <input type="date" id="eventdate">
-        </div>
-        <div class="cl-field">
-          <label>End Date</label>
-          <input type="date" id="eventenddate">
-        </div>
-      </div>
-
-      <div class="cl-row">
-        <div class="cl-field">
-          <label>City</label>
-          <input type="text" id="eventcity" placeholder="e.g. Kuala Lumpur" maxlength="100">
-        </div>
-        <div class="cl-field">
-          <label>Country</label>
-          <input type="text" id="eventcountry" placeholder="e.g. Malaysia" maxlength="100">
-        </div>
-      </div>
-
-      <div class="cl-field">
-        <label>Visibility</label>
+      </li>
+      <li>
+        <div class="label-block"><label for="eventdate">Start Date</label></div>
+        <input type="date" id="eventdate">
+      </li>
+      <li>
+        <div class="label-block"><label for="eventenddate">End Date</label></div>
+        <input type="date" id="eventenddate">
+      </li>
+      <li>
+        <div class="label-block"><label for="eventcity">City</label></div>
+        <input type="text" id="eventcity" placeholder="e.g. Kuala Lumpur" maxlength="100">
+      </li>
+      <li>
+        <div class="label-block"><label for="eventcountry">Country</label></div>
+        <input type="text" id="eventcountry" placeholder="e.g. Malaysia" maxlength="100">
+      </li>
+      <li>
+        <div class="label-block"><label for="eventpublic">Visibility</label></div>
         <select id="eventpublic">
-          <option value="private">🔒 Private — not listed publicly</option>
-          <option value="public">🌐 Public — shown on CloudLink events page</option>
+          <option value="private">Private — not listed publicly</option>
+          <option value="public">Public — shown on CloudLink events page</option>
         </select>
-      </div>
-
-      <div class="cl-field">
-        <label>Description</label>
+      </li>
+      <li>
+        <div class="label-block"><label for="eventdesc">Description</label></div>
         <textarea id="eventdesc" placeholder="Brief description of the event..." maxlength="500"></textarea>
-      </div>
-    </div>
+      </li>
+    </ol>
 
-    <!-- Event Logo -->
-    <div class="cl-card">
-      <div class="cl-card-title">Event Logo <span style="font-size:0.7rem;text-transform:none;color:var(--color-text-secondary,#9ab);letter-spacing:0;">(optional — JPEG, PNG or WebP, max 5MB)</span></div>
-
-      <div class="cl-dropzone" id="dropzone"
-           ondragover="onDragOver(event)" ondragleave="onDragLeave()" ondrop="onDrop(event)"
-           onclick="onDropzoneClick()">
-
-        <div class="cl-dropzone-empty" id="dz-empty">
-          <span class="cl-dropzone-icon">🖼️</span>
-          <p class="cl-dropzone-text">Drag &amp; drop your logo here<br>
-            or <span class="cl-dropzone-link">click to browse</span></p>
-          <p class="cl-dropzone-hint">JPEG, PNG, WebP · max 5MB</p>
+    <h2>Event Logo <span style="font-weight:400;font-size:0.75em;">(optional — JPEG, PNG or WebP, max 5MB)</span></h2>
+    <ol class="form">
+      <li>
+        <div class="label-block"><label>Logo Image</label></div>
+        <div style="flex:1 1 0;margin-left:0.5em;">
+          <div class="cl-dropzone" id="dropzone"
+               ondragover="onDragOver(event)" ondragleave="onDragLeave()" ondrop="onDrop(event)"
+               onclick="onDropzoneClick()">
+            <div class="cl-dropzone-empty" id="dz-empty">
+              Drag &amp; drop image here, or click to browse
+            </div>
+            <div class="cl-dropzone-preview" id="dz-preview" style="display:none">
+              <img class="cl-preview-img" id="preview-img" src="" alt="Preview">
+              <button type="button" class="cl-preview-remove" onclick="event.stopPropagation(); clearImage()">Remove</button>
+            </div>
+          </div>
+          <input type="file" id="file-input" accept="image/jpeg,image/png,image/webp" style="display:none" onchange="onFileSelected(event)">
+          <div class="cl-upload-error" id="upload-error"></div>
         </div>
+      </li>
+    </ol>
 
-        <div class="cl-dropzone-preview" id="dz-preview" style="display:none">
-          <img class="cl-preview-img" id="preview-img" src="" alt="Preview">
-          <button class="cl-preview-remove" onclick="event.stopPropagation(); clearImage()" title="Remove">✕</button>
-        </div>
-      </div>
-
-      <input type="file" id="file-input" accept="image/jpeg,image/png,image/webp" style="display:none" onchange="onFileSelected(event)">
-      <div class="cl-upload-error" id="upload-error"></div>
-      <div class="cl-upload-status" id="upload-status"></div>
-    </div>
-
-    <!-- Submit -->
-    <div class="cl-card">
-      <div class="cl-btn-row">
-        <button class="cl-btn cl-btn-primary" id="submit-btn" onclick="submitForm()">
-          <span class="cl-spinner"></span>
-          <span class="cl-btn-label">Register Event</span>
-        </button>
-        {% if eventid and eventkey %}
-        <button class="cl-btn cl-btn-secondary" onclick="cancelForm()">Cancel</button>
-        {% endif %}
-      </div>
-      <div class="cl-status" id="form-status"></div>
+    <div style="text-align:center; margin-top:1.5em;">
+      <button type="button" id="submit-btn" onclick="submitForm()">
+        <span class="cl-spinner"></span>
+        <span id="submit-label">Register Event</span>
+      </button>
+      {% if eventid and eventkey %}
+      &nbsp;<button type="button" onclick="cancelForm()">Cancel</button>
+      {% endif %}
+      <div id="form-status" style="margin-top:0.75em;font-size:0.9em;display:none;"></div>
     </div>
 
   </div><!-- /form-section -->
 
   <!-- ── Success ── -->
-  <div id="success-section">
-    <div class="cl-card">
-      <div class="cl-success-icon">🎉</div>
-      <div class="cl-success-msg">
-        Event registered!<br>
-        <strong>Keys saved to your timer automatically.</strong><br>
-        Head back to Format to start racing.
-      </div>
-      <div class="cl-field">
-        <label>Event ID</label>
-        <div class="cl-key-row">
+  <div id="success-section" style="display:none">
+    <div class="cl-success-icon">🎉</div>
+    <h4 style="text-align:center;">Event Registered!</h4>
+    <p style="text-align:center;">Keys saved to your timer. Head back to Format to start racing.</p>
+    <ol class="form">
+      <li>
+        <div class="label-block"><label>Event ID</label></div>
+        <div class="cl-key-wrap">
           <div class="cl-key-box" id="new-eventid">—</div>
-          <button class="cl-copy-btn" onclick="copyText(document.getElementById('new-eventid').textContent, this)">Copy</button>
+          <button type="button" onclick="copyText(document.getElementById('new-eventid').textContent, this)">Copy</button>
         </div>
-      </div>
-      <div class="cl-field">
-        <label>Private Key</label>
-        <div class="cl-key-row">
+      </li>
+      <li>
+        <div class="label-block"><label>Private Key</label></div>
+        <div class="cl-key-wrap">
           <div class="cl-key-box" id="new-eventkey">—</div>
-          <button class="cl-copy-btn" onclick="copyText(document.getElementById('new-eventkey').textContent, this)">Copy</button>
+          <button type="button" onclick="copyText(document.getElementById('new-eventkey').textContent, this)">Copy</button>
         </div>
-      </div>
-      <div class="cl-btn-row" style="margin-top:18px;">
-        <a class="cl-btn cl-btn-primary" href="/format">Done — Back to Format</a>
-        <button class="cl-btn cl-btn-secondary" onclick="registerAnother()">Register Another</button>
-      </div>
-    </div>
+      </li>
+      <li>
+        <div class="label-block"></div>
+        <div>
+          <a href="/format" class="button-like">Done — Back to Format</a>
+          &nbsp;
+          <button type="button" onclick="registerAnother()">Register Another</button>
+        </div>
+      </li>
+    </ol>
   </div>
 
-</div><!-- /cl-container -->
+</div><!-- /cl-page-wrap -->
 
 <script>
-  // ── State ──────────────────────────────────────────────────────────────────
   var selectedFile = null;
   var previewUrl   = null;
+  var today        = new Date().toISOString().split('T')[0];
 
-  // ── Init ───────────────────────────────────────────────────────────────────
-  var today = new Date().toISOString().split('T')[0];
   document.getElementById('eventdate').value    = today;
   document.getElementById('eventenddate').value = today;
 
@@ -341,10 +297,8 @@
     if (file) handleFile(file);
   }
 
-  // ── File handling ──────────────────────────────────────────────────────────
   function handleFile(file) {
     hideUploadError();
-
     var allowed = ['image/jpeg', 'image/png', 'image/webp'];
     if (allowed.indexOf(file.type) === -1) {
       showUploadError('Only JPEG, PNG or WebP images are allowed.');
@@ -354,11 +308,9 @@
       showUploadError('Image must be under 5MB.');
       return;
     }
-
     selectedFile = file;
     if (previewUrl) URL.revokeObjectURL(previewUrl);
     previewUrl = URL.createObjectURL(file);
-
     document.getElementById('preview-img').src = previewUrl;
     document.getElementById('dz-empty').style.display   = 'none';
     document.getElementById('dz-preview').style.display = 'block';
@@ -374,35 +326,32 @@
     document.getElementById('dz-preview').style.display = 'none';
     document.getElementById('dropzone').classList.remove('has-image');
     hideUploadError();
-    hideUploadStatus();
   }
 
   // ── Submit ─────────────────────────────────────────────────────────────────
   function submitForm() {
     var eventname = document.getElementById('eventname').value.trim();
     var emailid   = document.getElementById('emailid').value.trim();
-
-    if (!eventname) { showStatus('Event name is required.', 'error'); return; }
-    if (!emailid)   { showStatus('Email address is required.', 'error'); return; }
+    if (!eventname) { showStatus('Event name is required.'); return; }
+    if (!emailid)   { showStatus('Email address is required.'); return; }
 
     hideStatus();
     setLoading(true);
 
+    var startDate = document.getElementById('eventdate').value;
+    var endDate   = document.getElementById('eventenddate').value || startDate;
+
     var fd = new FormData();
     fd.append('eventname',    eventname);
     fd.append('emailid',      emailid);
-    fd.append('eventdate',    document.getElementById('eventdate').value);
-    fd.append('eventenddate', document.getElementById('eventenddate').value || document.getElementById('eventdate').value);
+    fd.append('eventdate',    startDate);
+    fd.append('eventenddate', endDate);
     fd.append('eventcity',    document.getElementById('eventcity').value.trim());
     fd.append('eventcountry', document.getElementById('eventcountry').value.trim());
     fd.append('eventdesc',    document.getElementById('eventdesc').value.trim());
     fd.append('eventpublic',  document.getElementById('eventpublic').value);
     fd.append('has_image',    selectedFile ? 'true' : 'false');
-
-    if (selectedFile) {
-      fd.append('image_file', selectedFile, selectedFile.name);
-      showStatus('Creating event...', 'info');
-    }
+    if (selectedFile) fd.append('image_file', selectedFile, selectedFile.name);
 
     fetch('/cloudlink/register', { method: 'POST', body: fd })
       .then(function(r) { return r.json(); })
@@ -416,24 +365,26 @@
           var ex = document.getElementById('existing-section');
           if (ex) ex.style.display = 'none';
         } else {
-          showStatus('Error: ' + (data.error || 'Registration failed'), 'error');
+          showStatus('Error: ' + (data.error || 'Registration failed'));
         }
       })
       .catch(function() {
         setLoading(false);
-        showStatus('Network error — check internet connection.', 'error');
+        showStatus('Network error — check internet connection.');
       });
   }
 
-  // ── Helpers ────────────────────────────────────────────────────────────────
-  function setLoading(loading) {
+  function setLoading(on) {
     var btn = document.getElementById('submit-btn');
-    if (loading) { btn.classList.add('submitting'); btn.disabled = true; }
-    else         { btn.classList.remove('submitting'); btn.disabled = false; }
+    var lbl = document.getElementById('submit-label');
+    btn.disabled = on;
+    if (on) { btn.classList.add('cl-loading'); lbl.textContent = 'Registering...'; }
+    else    { btn.classList.remove('cl-loading'); lbl.textContent = 'Register Event'; }
   }
-  function showStatus(msg, type) {
+  function showStatus(msg) {
     var el = document.getElementById('form-status');
-    el.textContent = msg; el.className = 'cl-status ' + type; el.style.display = 'block';
+    el.textContent = msg; el.style.display = 'block';
+    el.style.color = 'hsl(8.2, 86.5%, 53.7%)';
   }
   function hideStatus() { document.getElementById('form-status').style.display = 'none'; }
   function showUploadError(msg) {
@@ -441,11 +392,6 @@
     el.textContent = msg; el.style.display = 'block';
   }
   function hideUploadError() { document.getElementById('upload-error').style.display = 'none'; }
-  function showUploadStatus(msg) {
-    var el = document.getElementById('upload-status');
-    el.textContent = msg; el.style.display = 'block';
-  }
-  function hideUploadStatus() { document.getElementById('upload-status').style.display = 'none'; }
 
   function showForm() {
     document.getElementById('existing-section').style.display = 'none';
@@ -458,14 +404,12 @@
   function registerAnother() {
     document.getElementById('success-section').style.display = 'none';
     document.getElementById('form-section').style.display    = 'block';
-    document.getElementById('eventname').value    = '';
-    document.getElementById('emailid').value      = '';
+    ['eventname','emailid','eventcity','eventcountry','eventdesc'].forEach(function(id) {
+      document.getElementById(id).value = '';
+    });
     document.getElementById('eventdate').value    = today;
     document.getElementById('eventenddate').value = today;
-    document.getElementById('eventcity').value    = '';
-    document.getElementById('eventcountry').value = '';
     document.getElementById('eventpublic').value  = 'private';
-    document.getElementById('eventdesc').value    = '';
     clearImage();
     hideStatus();
   }

--- a/custom_plugins/cloudlink/templates/cloudlink/setup.html
+++ b/custom_plugins/cloudlink/templates/cloudlink/setup.html
@@ -3,25 +3,53 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>CloudLink — Event Setup</title>
+  <title>Cloudlink — Event Setup</title>
   <link rel="stylesheet" href="/static/rotorhazard.css">
   <link rel="apple-touch-icon" sizes="180x180" href="/static/image/apple-touch-icon.png">
   <link rel="icon" type="image/png" sizes="32x32" href="/static/image/favicon-32x32.png">
   <style>
     /* Only additions — everything else inherits from rotorhazard.css */
 
+    /* ── Navbar ── */
+    .cl-navbar {
+      background: var(--color-interface-bg, #1a1a2e);
+      border-bottom: 2px solid hsl(var(--hue_1), var(--sat_1), var(--lum_1_high));
+      padding: 0 1.25em;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      height: 3em;
+      position: sticky;
+      top: 0;
+      z-index: 100;
+    }
+    .cl-navbar-brand {
+      display: flex;
+      align-items: center;
+      gap: 0.5em;
+      font-size: 1em;
+      font-weight: 700;
+      color: var(--color-text, #dde);
+      text-decoration: none;
+    }
+    .cl-navbar-brand span.cl-brand-dim {
+      font-weight: 400;
+      opacity: 0.55;
+      font-size: 0.85em;
+    }
+    .cl-navbar-back {
+      font-size: 0.85em;
+    }
+
     .cl-page-wrap {
       max-width: 41em;
       margin: 0 auto;
-      padding: 1em 1em 4em;
+      padding: 1.5em 1em 4em;
     }
 
-    /* Back link row */
+    /* Back link row — keep for spacing below nav */
     .cl-topbar {
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-      margin-bottom: 1.5em;
+      display: none; /* replaced by navbar */
     }
 
     /* Drop zone — only custom element */
@@ -118,6 +146,13 @@
   </style>
 </head>
 <body>
+
+<nav class="cl-navbar">
+  <a class="cl-navbar-brand" href="/cloudlink/setup">
+    RotorHazard Cloudlink <span class="cl-brand-dim">— Plugin</span>
+  </a>
+  <a href="/format" class="button-like cl-navbar-back">← Back to Format</a>
+</nav>
 
 <div class="cl-page-wrap">
 

--- a/custom_plugins/cloudlink/templates/cloudlink/setup.html
+++ b/custom_plugins/cloudlink/templates/cloudlink/setup.html
@@ -306,19 +306,19 @@
         <div class="col-12 col-md-6">
           <div class="mb-3">
             <label class="form-label" for="eventname">Event Name <span class="text-danger">*</span></label>
-            <input type="text" class="form-control" id="eventname" placeholder="e.g. UGKL FPV Round 3" maxlength="100">
+            <input type="text" class="form-control" id="eventname" placeholder="e.g. City FPV Race Round 1" maxlength="100">
           </div>
           <div class="mb-3">
             <label class="form-label" for="emailid">Race Director Email <span class="text-danger">*</span></label>
-            <input type="text" class="form-control" id="emailid" placeholder="e.g. director@example.com" maxlength="254">
+            <input type="text" class="form-control" id="emailid" placeholder="e.g. you@example.com" maxlength="254">
           </div>
           <div class="mb-3">
-            <label class="form-label" for="eventdate">Start Date</label>
-            <input type="date" class="form-control" id="eventdate">
+            <label class="form-label" for="eventdate">Start Date <span class="text-danger">*</span></label>
+            <input type="date" class="form-control" id="eventdate" required>
           </div>
           <div class="mb-3">
-            <label class="form-label" for="eventenddate">End Date</label>
-            <input type="date" class="form-control" id="eventenddate">
+            <label class="form-label" for="eventenddate">End Date <span class="text-danger">*</span></label>
+            <input type="date" class="form-control" id="eventenddate" required>
           </div>
         </div>
 
@@ -326,17 +326,17 @@
         <div class="col-12 col-md-6">
           <div class="mb-3">
             <label class="form-label" for="eventcity">City</label>
-            <input type="text" class="form-control" id="eventcity" placeholder="e.g. Kuala Lumpur" maxlength="100">
+            <input type="text" class="form-control" id="eventcity" placeholder="City" maxlength="100">
           </div>
           <div class="mb-3">
             <label class="form-label" for="eventcountry">Country</label>
-            <input type="text" class="form-control" id="eventcountry" placeholder="e.g. Malaysia" maxlength="100">
+            <input type="text" class="form-control" id="eventcountry" placeholder="Country" maxlength="100">
           </div>
           <div class="mb-3">
             <label class="form-label" for="eventpublic">Visibility</label>
             <select class="form-select" id="eventpublic">
-              <option value="private">Private — not listed publicly</option>
               <option value="public">Public — shown on Cloudlink events page</option>
+              <option value="private">Private — not listed publicly</option>
             </select>
           </div>
           <div class="mb-3">
@@ -499,14 +499,17 @@
 
   // ── Submit ─────────────────────────────────────────────────────────────────
   function submitForm() {
-    var eventname = document.getElementById('eventname').value.trim();
-    var emailid   = document.getElementById('emailid').value.trim();
-    if (!eventname) { showStatus('Event name is required.'); return; }
-    if (!emailid)   { showStatus('Email address is required.'); return; }
+    var eventname  = document.getElementById('eventname').value.trim();
+    var emailid    = document.getElementById('emailid').value.trim();
+    var startDate  = document.getElementById('eventdate').value;
+    var endDate    = document.getElementById('eventenddate').value;
+    if (!eventname)  { showStatus('Event name is required.'); return; }
+    if (!emailid)    { showStatus('Email address is required.'); return; }
+    if (!startDate)  { showStatus('Start date is required.'); return; }
+    if (!endDate)    { showStatus('End date is required.'); return; }
     hideStatus();
     setLoading(true);
-    var startDate = document.getElementById('eventdate').value;
-    var endDate   = document.getElementById('eventenddate').value || startDate;
+    endDate = endDate || startDate;
     var fd = new FormData();
     fd.append('eventname',    eventname);
     fd.append('emailid',      emailid);

--- a/custom_plugins/cloudlink/templates/cloudlink/setup.html
+++ b/custom_plugins/cloudlink/templates/cloudlink/setup.html
@@ -4,64 +4,158 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Cloudlink — Event Setup</title>
-  <link rel="stylesheet" href="/static/rotorhazard.css">
   <link rel="apple-touch-icon" sizes="180x180" href="/static/image/apple-touch-icon.png">
   <link rel="icon" type="image/png" sizes="32x32" href="/static/image/favicon-32x32.png">
+  <!-- Bootstrap 5 -->
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+  <!-- Bootstrap Icons -->
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
   <style>
-    /* Only additions — everything else inherits from rotorhazard.css */
+    :root {
+      --cl-orange: #ee7a28;
+      --cl-orange-dark: #c45e10;
+      --cl-bg: #f8f9fa;
+      --cl-sidebar-width: 220px;
+    }
 
-    /* ── Navbar ── */
-    .cl-navbar {
-      background: #ee7a28;
-      border-bottom: 2px solid #c45e10;
-      padding: 0 1.25em;
+    body {
+      background: var(--cl-bg);
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    }
+
+    /* ── Top Navbar ── */
+    .cl-topnav {
+      background: var(--cl-orange);
+      height: 52px;
       display: flex;
       align-items: center;
       justify-content: space-between;
-      height: 3em;
-      position: sticky;
-      top: 0;
-      z-index: 100;
+      padding: 0 1rem;
+      position: fixed;
+      top: 0; left: 0; right: 0;
+      z-index: 1030;
     }
-    .cl-navbar-brand {
-      display: flex;
-      align-items: center;
-      gap: 0.5em;
-      font-size: 1em;
+    .cl-topnav-brand {
       font-weight: 700;
+      font-size: 1rem;
       color: #fff;
       text-decoration: none;
+      letter-spacing: 0.01em;
     }
-    .cl-navbar-brand span.cl-brand-dim {
+    .cl-topnav-brand span {
       font-weight: 400;
       opacity: 0.75;
       font-size: 0.85em;
     }
-    .cl-navbar-back {
-      font-size: 0.85em;
-      color: #fff !important;
-      border-color: rgba(255,255,255,0.5) !important;
+    .cl-topnav-back {
+      font-size: 0.82rem;
+      color: #fff;
+      text-decoration: none;
+      opacity: 0.85;
+      border: 1px solid rgba(255,255,255,0.45);
+      border-radius: 4px;
+      padding: 3px 10px;
     }
-    .cl-navbar-back:hover {
-      background: rgba(255,255,255,0.15) !important;
-      color: #fff !important;
+    .cl-topnav-back:hover { opacity: 1; color: #fff; background: rgba(255,255,255,0.15); }
+
+    /* Hamburger button (mobile only) */
+    .cl-hamburger {
+      display: none;
+      background: none;
+      border: none;
+      cursor: pointer;
+      padding: 4px;
+    }
+    .cl-hamburger span {
+      display: block;
+      width: 22px;
+      height: 2px;
+      background: #fff;
+      margin: 4px 0;
+      border-radius: 2px;
     }
 
-    .cl-page-wrap {
-      max-width: 41em;
-      margin: 0 auto;
-      padding: 1.5em 1em 4em;
+    /* ── Sidebar ── */
+    .cl-sidebar {
+      position: fixed;
+      top: 52px;
+      left: 0;
+      bottom: 0;
+      width: var(--cl-sidebar-width);
+      background: #fff;
+      border-right: 1px solid #dee2e6;
+      overflow-y: auto;
+      z-index: 1020;
+      transition: transform 0.25s ease;
+    }
+    .cl-sidebar-nav {
+      list-style: none;
+      padding: 1rem 0;
+      margin: 0;
+    }
+    .cl-sidebar-nav li a {
+      display: flex;
+      align-items: center;
+      gap: 0.6em;
+      padding: 0.65rem 1.25rem;
+      color: #495057;
+      text-decoration: none;
+      font-size: 0.9rem;
+      border-left: 3px solid transparent;
+      transition: all 0.15s;
+    }
+    .cl-sidebar-nav li a:hover {
+      background: #fff3ec;
+      color: var(--cl-orange);
+      border-left-color: var(--cl-orange);
+    }
+    .cl-sidebar-nav li a.active {
+      background: #fff3ec;
+      color: var(--cl-orange);
+      border-left-color: var(--cl-orange);
+      font-weight: 600;
+    }
+    .cl-sidebar-nav .cl-nav-icon { font-size: 1em; width: 1.2em; text-align: center; }
+    .cl-sidebar-label {
+      font-size: 0.7rem;
+      font-weight: 700;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+      color: #adb5bd;
+      padding: 0.75rem 1.25rem 0.25rem;
+    }
+    .cl-sidebar-divider {
+      border-top: 1px solid #f0f0f0;
+      margin: 0.5rem 0;
+    }
+    .cl-nav-disabled {
+      opacity: 0.38;
+      cursor: not-allowed !important;
+      pointer-events: none;
     }
 
-    /* Back link row — keep for spacing below nav */
-    .cl-topbar {
-      display: none; /* replaced by navbar */
+    /* ── Main content ── */
+    .cl-main {
+      margin-left: var(--cl-sidebar-width);
+      margin-top: 52px;
+      padding: 1.75rem 2rem 4rem;
+      max-width: 720px;
     }
 
-    /* Drop zone — only custom element */
+    /* ── Overlay for mobile sidebar ── */
+    .cl-overlay {
+      display: none;
+      position: fixed;
+      inset: 0;
+      background: rgba(0,0,0,0.4);
+      z-index: 1015;
+    }
+    .cl-overlay.show { display: block; }
+
+    /* ── Dropzone ── */
     .cl-dropzone {
-      border: 2px dashed hsl(var(--hue_0), var(--sat_0), var(--lum_0_low));
-      border-radius: 0.25rem;
+      border: 2px dashed #ced4da;
+      border-radius: 6px;
       min-height: 90px;
       display: flex;
       align-items: center;
@@ -70,251 +164,284 @@
       transition: border-color 0.15s, background 0.15s;
       position: relative;
       overflow: hidden;
-      width: 100%;
-      box-sizing: border-box;
+      background: #fdfdfd;
     }
     .cl-dropzone:hover, .cl-dropzone.drag-over {
-      border-color: hsl(var(--hue_1), var(--sat_1), var(--lum_1_high));
+      border-color: var(--cl-orange);
+      background: #fff9f5;
     }
-    .cl-dropzone.has-image {
-      cursor: default;
-      border-style: solid;
-    }
+    .cl-dropzone.has-image { cursor: default; border-style: solid; border-color: var(--cl-orange); }
     .cl-dropzone-empty {
-      text-align: center;
-      padding: 16px;
-      pointer-events: none;
-      font-style: italic;
-      opacity: 0.7;
-      font-size: 0.85em;
+      text-align: center; padding: 16px;
+      pointer-events: none; font-style: italic;
+      opacity: 0.6; font-size: 0.85em;
     }
-    .cl-dropzone-preview {
-      width: 100%;
-      height: 100px;
-      position: relative;
-    }
-    .cl-preview-img {
-      width: 100%; height: 100%;
-      object-fit: cover; display: block;
-    }
+    .cl-dropzone-preview { width: 100%; height: 100px; position: relative; }
+    .cl-preview-img { width: 100%; height: 100%; object-fit: cover; display: block; }
     .cl-preview-remove {
       position: absolute; top: 4px; right: 4px;
       background: rgba(180,40,40,0.85); color: #fff;
-      border: none; border-radius: 0.25rem;
+      border: none; border-radius: 4px;
       padding: 2px 8px; cursor: pointer; font-size: 0.8em;
     }
-    .cl-upload-error {
-      color: hsl(8.2, 86.5%, 53.7%);
-      font-size: 0.8em; margin-top: 4px; display: none;
-    }
+    .cl-upload-error { color: #dc3545; font-size: 0.82em; margin-top: 4px; display: none; }
 
-    /* Key display box */
-    .cl-key-wrap {
-      display: flex; gap: 0.5em; align-items: center; margin-top: 0.25em;
-    }
+    /* ── Key box ── */
+    .cl-key-wrap { display: flex; gap: 0.5em; align-items: center; }
     .cl-key-box {
-      flex: 1;
-      border: solid 0.125em hsl(var(--hue_0), var(--sat_0), var(--lum_0_low));
-      border-radius: 0.25rem;
-      padding: 0.25rem 0.5rem;
-      font-family: monospace;
-      font-size: 1em;
-      background: #fff;
-      color: #000;
-      word-break: break-all;
-    }
-    @media (prefers-color-scheme: dark) {
-      .cl-key-box { background: #000; color: #fff; }
+      flex: 1; border: 1px solid #ced4da; border-radius: 4px;
+      padding: 0.4rem 0.6rem; font-family: monospace; font-size: 0.95em;
+      background: #f8f9fa; word-break: break-all;
     }
 
-    /* Spinner inside button */
+    /* ── Spinner ── */
     .cl-spinner {
-      display: none;
-      width: 0.9em; height: 0.9em;
+      display: none; width: 0.9em; height: 0.9em;
       border: 2px solid rgba(255,255,255,0.3);
-      border-top-color: #fff;
-      border-radius: 50%;
+      border-top-color: #fff; border-radius: 50%;
       animation: cl-spin 0.65s linear infinite;
-      vertical-align: middle;
-      margin-right: 0.3em;
+      vertical-align: middle; margin-right: 0.3em;
     }
     .cl-loading .cl-spinner { display: inline-block; }
     @keyframes cl-spin { to { transform: rotate(360deg); } }
 
-    /* Success icon */
-    .cl-success-icon { font-size: 2em; text-align: center; padding: 0.5em 0; }
-
-    /* Row layout for paired fields */
-    .cl-field-row { display: flex; gap: 1em; }
-    .cl-field-row > * { flex: 1; }
-
-    ol.form > li > .cl-dropzone { flex: 1 1 0; margin-left: 0.5em; }
+    /* ── Mobile responsive ── */
+    @media (max-width: 767px) {
+      .cl-hamburger { display: block; }
+      .cl-sidebar {
+        transform: translateX(-100%);
+      }
+      .cl-sidebar.open {
+        transform: translateX(0);
+      }
+      .cl-main {
+        margin-left: 0;
+        padding: 1.25rem 1rem 4rem;
+      }
+      .cl-topnav-back { display: none; }
+    }
   </style>
 </head>
 <body>
 
-<nav class="cl-navbar">
-  <a class="cl-navbar-brand" href="/cloudlink/setup">
-    RotorHazard Cloudlink <span class="cl-brand-dim">— Plugin</span>
-  </a>
-  <a href="/format" class="button-like cl-navbar-back">← Back to Format</a>
+<!-- ── Top Navbar ── -->
+<nav class="cl-topnav">
+  <div class="d-flex align-items-center gap-3">
+    <button class="cl-hamburger" onclick="toggleSidebar()" aria-label="Menu">
+      <span></span><span></span><span></span>
+    </button>
+    <a class="cl-topnav-brand" href="/cloudlink/setup">
+      RotorHazard Cloudlink <span>— Plugin</span>
+    </a>
+  </div>
+  <a href="/format" class="cl-topnav-back">← Back to Format</a>
 </nav>
 
-<div class="cl-page-wrap">
+<!-- ── Sidebar overlay (mobile) ── -->
+<div class="cl-overlay" id="cl-overlay" onclick="closeSidebar()"></div>
 
-  <div class="cl-topbar">
-    <h3 style="margin:0;">CloudLink — Event Setup</h3>
-    <a href="/format" class="button-like">← Back to Format</a>
-  </div>
+<!-- ── Sidebar ── -->
+<aside class="cl-sidebar" id="cl-sidebar">
+  <ul class="cl-sidebar-nav">
+    <li class="cl-sidebar-label">Setup</li>
+    <li>
+      <a href="#" class="active" onclick="showTab('event-setup', this)">
+        <i class="bi bi-calendar-event cl-nav-icon"></i> Event Setup <sup style="font-size:0.6em;font-weight:700;color:var(--cl-orange);letter-spacing:0.05em;">NEW</sup>
+      </a>
+    </li>
+    <li>
+      <a href="#" class="cl-nav-disabled" onclick="return false;">
+        <i class="bi bi-diagram-3 cl-nav-icon"></i> Bracket Configuration
+      </a>
+    </li>
+    <li class="cl-sidebar-divider"></li>
+    <li class="cl-sidebar-label">Live</li>
+    <li>
+      <a href="#" class="cl-nav-disabled" onclick="return false;">
+        <i class="bi bi-broadcast cl-nav-icon"></i> Realtime Update
+      </a>
+    </li>
+  </ul>
+</aside>
 
-  <!-- ── Already registered ── -->
-  {% if eventid and eventkey %}
-  <div id="existing-section">
-    <h4>✅ Event Registered</h4>
-    <ol class="form">
-      <li>
-        <div class="label-block"><label>Event ID</label></div>
+<!-- ── Main content ── -->
+<main class="cl-main">
+
+  <!-- ══ TAB: Event Setup ══ -->
+  <div id="tab-event-setup">
+
+    <!-- Already registered -->
+    {% if eventid and eventkey %}
+    <div id="existing-section">
+      <h5 class="mb-3">✅ Event Registered</h5>
+      <div class="mb-3">
+        <label class="form-label fw-semibold">Event ID</label>
         <div class="cl-key-wrap">
           <div class="cl-key-box">{{ eventid }}</div>
-          <button type="button" onclick="copyText('{{ eventid }}', this)">Copy</button>
+          <button type="button" class="btn btn-sm btn-outline-secondary" onclick="copyText('{{ eventid }}', this)">Copy</button>
         </div>
-      </li>
-      <li>
-        <div class="label-block"><label>Private Key</label></div>
+      </div>
+      <div class="mb-3">
+        <label class="form-label fw-semibold">Private Key</label>
         <div class="cl-key-wrap">
           <div class="cl-key-box">{{ eventkey }}</div>
-          <button type="button" onclick="copyText('{{ eventkey }}', this)">Copy</button>
+          <button type="button" class="btn btn-sm btn-outline-secondary" onclick="copyText('{{ eventkey }}', this)">Copy</button>
         </div>
-      </li>
-      <li>
-        <div class="label-block"></div>
-        <div>
-          <a href="/format" class="button-like">Done — Back to Format</a>
-          &nbsp;
-          <button type="button" onclick="showForm()">Register a Different Event</button>
-        </div>
-      </li>
-    </ol>
-  </div>
-  {% endif %}
-
-  <!-- ── Registration form ── -->
-  <div id="form-section" {% if eventid and eventkey %}style="display:none"{% endif %}>
-
-    <h2>Event Details</h2>
-    <ol class="form">
-      <li>
-        <div class="label-block"><label for="eventname">Event Name *</label></div>
-        <input type="text" id="eventname" placeholder="e.g. UGKL FPV Round 3" maxlength="100">
-      </li>
-      <li>
-        <div class="label-block"><label for="emailid">Race Director Email *</label></div>
-        <input type="text" id="emailid" placeholder="e.g. director@example.com" maxlength="254">
-      </li>
-      <li>
-        <div class="label-block"><label for="eventdate">Start Date</label></div>
-        <input type="date" id="eventdate">
-      </li>
-      <li>
-        <div class="label-block"><label for="eventenddate">End Date</label></div>
-        <input type="date" id="eventenddate">
-      </li>
-      <li>
-        <div class="label-block"><label for="eventcity">City</label></div>
-        <input type="text" id="eventcity" placeholder="e.g. Kuala Lumpur" maxlength="100">
-      </li>
-      <li>
-        <div class="label-block"><label for="eventcountry">Country</label></div>
-        <input type="text" id="eventcountry" placeholder="e.g. Malaysia" maxlength="100">
-      </li>
-      <li>
-        <div class="label-block"><label for="eventpublic">Visibility</label></div>
-        <select id="eventpublic">
-          <option value="private">Private — not listed publicly</option>
-          <option value="public">Public — shown on CloudLink events page</option>
-        </select>
-      </li>
-      <li>
-        <div class="label-block"><label for="eventdesc">Description</label></div>
-        <textarea id="eventdesc" placeholder="Brief description of the event..." maxlength="500"></textarea>
-      </li>
-    </ol>
-
-    <h2>Event Logo <span style="font-weight:400;font-size:0.75em;">(optional — JPEG, PNG or WebP, max 5MB)</span></h2>
-    <ol class="form">
-      <li>
-        <div class="label-block"><label>Logo Image</label></div>
-        <div style="flex:1 1 0;margin-left:0.5em;">
-          <div class="cl-dropzone" id="dropzone"
-               ondragover="onDragOver(event)" ondragleave="onDragLeave()" ondrop="onDrop(event)"
-               onclick="onDropzoneClick()">
-            <div class="cl-dropzone-empty" id="dz-empty">
-              Drag &amp; drop image here, or click to browse
-            </div>
-            <div class="cl-dropzone-preview" id="dz-preview" style="display:none">
-              <img class="cl-preview-img" id="preview-img" src="" alt="Preview">
-              <button type="button" class="cl-preview-remove" onclick="event.stopPropagation(); clearImage()">Remove</button>
-            </div>
-          </div>
-          <input type="file" id="file-input" accept="image/jpeg,image/png,image/webp" style="display:none" onchange="onFileSelected(event)">
-          <div class="cl-upload-error" id="upload-error"></div>
-        </div>
-      </li>
-    </ol>
-
-    <div style="text-align:center; margin-top:1.5em;">
-      <button type="button" id="submit-btn" onclick="submitForm()">
-        <span class="cl-spinner"></span>
-        <span id="submit-label">Register Event</span>
-      </button>
-      {% if eventid and eventkey %}
-      &nbsp;<button type="button" onclick="cancelForm()">Cancel</button>
-      {% endif %}
-      <div id="form-status" style="margin-top:0.75em;font-size:0.9em;display:none;"></div>
+      </div>
+      <div class="d-flex gap-2 mt-3">
+        <a href="/format" class="btn btn-sm" style="background:var(--cl-orange);color:#fff;">Done — Back to Format</a>
+        <button type="button" class="btn btn-sm btn-outline-secondary" onclick="showForm()">Register a Different Event</button>
+      </div>
     </div>
+    {% endif %}
 
-  </div><!-- /form-section -->
+    <!-- Registration form -->
+    <div id="form-section" {% if eventid and eventkey %}style="display:none"{% endif %}>
 
-  <!-- ── Success ── -->
-  <div id="success-section" style="display:none">
-    <div class="cl-success-icon">🎉</div>
-    <h4 style="text-align:center;">Event Registered!</h4>
-    <p style="text-align:center;">Keys saved to your timer. Head back to Format to start racing.</p>
-    <ol class="form">
-      <li>
-        <div class="label-block"><label>Event ID</label></div>
+      <h5 class="mb-3">Event Details</h5>
+      <div class="mb-3">
+        <label class="form-label" for="eventname">Event Name <span class="text-danger">*</span></label>
+        <input type="text" class="form-control" id="eventname" placeholder="e.g. UGKL FPV Round 3" maxlength="100">
+      </div>
+      <div class="mb-3">
+        <label class="form-label" for="emailid">Race Director Email <span class="text-danger">*</span></label>
+        <input type="text" class="form-control" id="emailid" placeholder="e.g. director@example.com" maxlength="254">
+      </div>
+      <div class="row g-3 mb-3">
+        <div class="col-6">
+          <label class="form-label" for="eventdate">Start Date</label>
+          <input type="date" class="form-control" id="eventdate">
+        </div>
+        <div class="col-6">
+          <label class="form-label" for="eventenddate">End Date</label>
+          <input type="date" class="form-control" id="eventenddate">
+        </div>
+      </div>
+      <div class="row g-3 mb-3">
+        <div class="col-6">
+          <label class="form-label" for="eventcity">City</label>
+          <input type="text" class="form-control" id="eventcity" placeholder="e.g. Kuala Lumpur" maxlength="100">
+        </div>
+        <div class="col-6">
+          <label class="form-label" for="eventcountry">Country</label>
+          <input type="text" class="form-control" id="eventcountry" placeholder="e.g. Malaysia" maxlength="100">
+        </div>
+      </div>
+      <div class="mb-3">
+        <label class="form-label" for="eventpublic">Visibility</label>
+        <select class="form-select" id="eventpublic">
+          <option value="private">Private — not listed publicly</option>
+          <option value="public">Public — shown on Cloudlink events page</option>
+        </select>
+      </div>
+      <div class="mb-3">
+        <label class="form-label" for="eventdesc">Description</label>
+        <textarea class="form-control" id="eventdesc" rows="3" placeholder="Brief description of the event..." maxlength="500"></textarea>
+      </div>
+
+      <h5 class="mb-2 mt-4">Event Logo <small class="text-muted fw-normal" style="font-size:0.75em;">optional — JPEG, PNG or WebP, max 5MB</small></h5>
+      <div class="cl-dropzone mb-1" id="dropzone"
+           ondragover="onDragOver(event)" ondragleave="onDragLeave()" ondrop="onDrop(event)"
+           onclick="onDropzoneClick()">
+        <div class="cl-dropzone-empty" id="dz-empty">
+          Drag &amp; drop image here, or click to browse
+        </div>
+        <div class="cl-dropzone-preview" id="dz-preview" style="display:none">
+          <img class="cl-preview-img" id="preview-img" src="" alt="Preview">
+          <button type="button" class="cl-preview-remove" onclick="event.stopPropagation(); clearImage()">Remove</button>
+        </div>
+      </div>
+      <input type="file" id="file-input" accept="image/jpeg,image/png,image/webp" style="display:none" onchange="onFileSelected(event)">
+      <div class="cl-upload-error" id="upload-error"></div>
+
+      <div class="mt-4">
+        <button type="button" class="btn px-4" id="submit-btn" onclick="submitForm()"
+                style="background:var(--cl-orange);color:#fff;">
+          <span class="cl-spinner"></span>
+          <span id="submit-label">Register Event</span>
+        </button>
+        {% if eventid and eventkey %}
+        <button type="button" class="btn btn-outline-secondary ms-2" onclick="cancelForm()">Cancel</button>
+        {% endif %}
+        <div id="form-status" class="mt-2 text-danger small" style="display:none;"></div>
+      </div>
+
+    </div><!-- /form-section -->
+
+    <!-- Success -->
+    <div id="success-section" style="display:none">
+      <div style="font-size:2em;text-align:center;padding:0.5em 0;">🎉</div>
+      <h5 class="text-center mb-1">Event Registered!</h5>
+      <p class="text-center text-muted small mb-4">Keys saved to your timer. Head back to Format to start racing.</p>
+      <div class="mb-3">
+        <label class="form-label fw-semibold">Event ID</label>
         <div class="cl-key-wrap">
           <div class="cl-key-box" id="new-eventid">—</div>
-          <button type="button" onclick="copyText(document.getElementById('new-eventid').textContent, this)">Copy</button>
+          <button type="button" class="btn btn-sm btn-outline-secondary" onclick="copyText(document.getElementById('new-eventid').textContent, this)">Copy</button>
         </div>
-      </li>
-      <li>
-        <div class="label-block"><label>Private Key</label></div>
+      </div>
+      <div class="mb-3">
+        <label class="form-label fw-semibold">Private Key</label>
         <div class="cl-key-wrap">
           <div class="cl-key-box" id="new-eventkey">—</div>
-          <button type="button" onclick="copyText(document.getElementById('new-eventkey').textContent, this)">Copy</button>
+          <button type="button" class="btn btn-sm btn-outline-secondary" onclick="copyText(document.getElementById('new-eventkey').textContent, this)">Copy</button>
         </div>
-      </li>
-      <li>
-        <div class="label-block"></div>
-        <div>
-          <a href="/format" class="button-like">Done — Back to Format</a>
-          &nbsp;
-          <button type="button" onclick="registerAnother()">Register Another</button>
-        </div>
-      </li>
-    </ol>
+      </div>
+      <div class="d-flex gap-2 mt-3">
+        <a href="/format" class="btn btn-sm" style="background:var(--cl-orange);color:#fff;">Done — Back to Format</a>
+        <button type="button" class="btn btn-sm btn-outline-secondary" onclick="registerAnother()">Register Another</button>
+      </div>
+    </div>
+
+  </div><!-- /tab-event-setup -->
+
+  <!-- ══ TAB: Bracket Configuration ══ -->
+  <div id="tab-bracket-config" style="display:none">
+    <h5 class="mb-2">Bracket Configuration</h5>
+    <p class="text-muted">Bracket configuration settings will appear here.</p>
   </div>
 
-</div><!-- /cl-page-wrap -->
+  <!-- ══ TAB: Realtime Update ══ -->
+  <div id="tab-realtime" style="display:none">
+    <h5 class="mb-2">Realtime Update</h5>
+    <p class="text-muted">Realtime sync status and controls will appear here.</p>
+  </div>
+
+</main>
 
 <script>
   var selectedFile = null;
   var previewUrl   = null;
   var today        = new Date().toISOString().split('T')[0];
-
   document.getElementById('eventdate').value    = today;
   document.getElementById('eventenddate').value = today;
+
+  // ── Sidebar toggle (mobile) ────────────────────────────────────────────────
+  function toggleSidebar() {
+    document.getElementById('cl-sidebar').classList.toggle('open');
+    document.getElementById('cl-overlay').classList.toggle('show');
+  }
+  function closeSidebar() {
+    document.getElementById('cl-sidebar').classList.remove('open');
+    document.getElementById('cl-overlay').classList.remove('show');
+  }
+
+  // ── Tab switching ──────────────────────────────────────────────────────────
+  function showTab(tabId, linkEl) {
+    // hide all tabs
+    ['event-setup', 'bracket-config', 'realtime'].forEach(function(t) {
+      document.getElementById('tab-' + t).style.display = 'none';
+    });
+    // show selected
+    document.getElementById('tab-' + tabId).style.display = 'block';
+    // update active link
+    document.querySelectorAll('.cl-sidebar-nav a').forEach(function(a) {
+      a.classList.remove('active');
+    });
+    if (linkEl) linkEl.classList.add('active');
+    // close sidebar on mobile after selection
+    closeSidebar();
+  }
 
   // ── Drag & Drop ────────────────────────────────────────────────────────────
   function onDropzoneClick() {
@@ -337,18 +464,11 @@
     var file = e.target.files && e.target.files[0];
     if (file) handleFile(file);
   }
-
   function handleFile(file) {
     hideUploadError();
     var allowed = ['image/jpeg', 'image/png', 'image/webp'];
-    if (allowed.indexOf(file.type) === -1) {
-      showUploadError('Only JPEG, PNG or WebP images are allowed.');
-      return;
-    }
-    if (file.size > 5 * 1024 * 1024) {
-      showUploadError('Image must be under 5MB.');
-      return;
-    }
+    if (allowed.indexOf(file.type) === -1) { showUploadError('Only JPEG, PNG or WebP images are allowed.'); return; }
+    if (file.size > 5 * 1024 * 1024) { showUploadError('Image must be under 5MB.'); return; }
     selectedFile = file;
     if (previewUrl) URL.revokeObjectURL(previewUrl);
     previewUrl = URL.createObjectURL(file);
@@ -357,7 +477,6 @@
     document.getElementById('dz-preview').style.display = 'block';
     document.getElementById('dropzone').classList.add('has-image');
   }
-
   function clearImage() {
     selectedFile = null;
     if (previewUrl) { URL.revokeObjectURL(previewUrl); previewUrl = null; }
@@ -375,13 +494,10 @@
     var emailid   = document.getElementById('emailid').value.trim();
     if (!eventname) { showStatus('Event name is required.'); return; }
     if (!emailid)   { showStatus('Email address is required.'); return; }
-
     hideStatus();
     setLoading(true);
-
     var startDate = document.getElementById('eventdate').value;
     var endDate   = document.getElementById('eventenddate').value || startDate;
-
     var fd = new FormData();
     fd.append('eventname',    eventname);
     fd.append('emailid',      emailid);
@@ -393,7 +509,6 @@
     fd.append('eventpublic',  document.getElementById('eventpublic').value);
     fd.append('has_image',    selectedFile ? 'true' : 'false');
     if (selectedFile) fd.append('image_file', selectedFile, selectedFile.name);
-
     fetch('/cloudlink/register', { method: 'POST', body: fd })
       .then(function(r) { return r.json(); })
       .then(function(data) {
@@ -409,12 +524,8 @@
           showStatus('Error: ' + (data.error || 'Registration failed'));
         }
       })
-      .catch(function() {
-        setLoading(false);
-        showStatus('Network error — check internet connection.');
-      });
+      .catch(function() { setLoading(false); showStatus('Network error — check internet connection.'); });
   }
-
   function setLoading(on) {
     var btn = document.getElementById('submit-btn');
     var lbl = document.getElementById('submit-label');
@@ -425,7 +536,6 @@
   function showStatus(msg) {
     var el = document.getElementById('form-status');
     el.textContent = msg; el.style.display = 'block';
-    el.style.color = 'hsl(8.2, 86.5%, 53.7%)';
   }
   function hideStatus() { document.getElementById('form-status').style.display = 'none'; }
   function showUploadError(msg) {
@@ -433,7 +543,6 @@
     el.textContent = msg; el.style.display = 'block';
   }
   function hideUploadError() { document.getElementById('upload-error').style.display = 'none'; }
-
   function showForm() {
     document.getElementById('existing-section').style.display = 'none';
     document.getElementById('form-section').style.display     = 'block';

--- a/custom_plugins/cloudlink/templates/cloudlink/setup.html
+++ b/custom_plugins/cloudlink/templates/cloudlink/setup.html
@@ -288,11 +288,76 @@
           <button type="button" class="btn btn-sm btn-outline-secondary" onclick="copyText('{{ eventkey }}', this)">Copy</button>
         </div>
       </div>
-      <div class="d-flex gap-2 mt-3">
+      <div class="d-flex gap-2 mt-3 flex-wrap">
         <a href="/format" class="btn btn-sm" style="background:var(--cl-orange);color:#fff;">Done — Back to Format</a>
-        <button type="button" class="btn btn-sm btn-outline-secondary" onclick="showForm()">Register a Different Event</button>
+        <button type="button" class="btn btn-sm btn-outline-secondary" onclick="showEditSection()">
+          <i class="bi bi-pencil-square"></i> Edit Event / Upload Image
+        </button>
+        <button type="button" class="btn btn-sm btn-outline-danger" onclick="showForm()">Register a Different Event</button>
       </div>
     </div>
+
+    <!-- ── Edit / Upload image section ── -->
+    <div id="edit-section" style="display:none">
+      <h5 class="mb-3">Edit Event</h5>
+
+      <!-- Disabled fields showing current event data -->
+      <div class="row g-3 mb-3">
+        <div class="col-12 col-md-6">
+          <label class="form-label">Event Name</label>
+          <input type="text" class="form-control" id="edit-eventname" disabled>
+        </div>
+        <div class="col-12 col-md-6">
+          <label class="form-label">Race Director Email</label>
+          <input type="text" class="form-control" id="edit-emailid" disabled>
+        </div>
+        <div class="col-6 col-md-3">
+          <label class="form-label">Start Date</label>
+          <input type="date" class="form-control" id="edit-eventdate" disabled>
+        </div>
+        <div class="col-6 col-md-3">
+          <label class="form-label">End Date</label>
+          <input type="date" class="form-control" id="edit-eventenddate" disabled>
+        </div>
+        <div class="col-12 col-md-6">
+          <label class="form-label">City / Country</label>
+          <input type="text" class="form-control" id="edit-location" disabled>
+        </div>
+        <div class="col-12 col-md-6">
+          <label class="form-label">Visibility</label>
+          <input type="text" class="form-control" id="edit-eventpublic" disabled>
+        </div>
+      </div>
+
+      <div class="alert alert-info py-2 px-3 small mb-3">
+        <i class="bi bi-info-circle"></i> Fields are read-only. You can update the event logo below.
+      </div>
+
+      <!-- Logo upload — active -->
+      <h6 class="mb-2">Event Logo</h6>
+      <div class="cl-dropzone mb-1" id="ex-dropzone"
+           ondragover="onDragOver(event,'ex-dropzone')" ondragleave="onDragLeave('ex-dropzone')" ondrop="onExDrop(event)"
+           onclick="onExDropzoneClick()">
+        <div class="cl-dropzone-empty" id="ex-dz-empty">Drag &amp; drop image here, or click to browse</div>
+        <div class="cl-dropzone-preview" id="ex-dz-preview" style="display:none">
+          <img class="cl-preview-img" id="ex-preview-img" src="" alt="Preview">
+          <button type="button" class="cl-preview-remove" onclick="event.stopPropagation(); clearExImage()">Remove</button>
+        </div>
+      </div>
+      <input type="file" id="ex-file-input" accept="image/jpeg,image/png,image/webp" style="display:none" onchange="onExFileSelected(event)">
+      <div class="cl-upload-error" id="ex-upload-error"></div>
+
+      <div class="mt-3 d-flex gap-2 align-items-center">
+        <button type="button" class="btn btn-sm px-3" id="ex-upload-btn" onclick="uploadExistingLogo()"
+                style="background:var(--cl-orange);color:#fff;" disabled>
+          <span class="cl-spinner" id="ex-spinner"></span>
+          <span id="ex-upload-label">Save Logo</span>
+        </button>
+        <button type="button" class="btn btn-sm btn-outline-secondary" onclick="hideEditSection()">Cancel</button>
+      </div>
+      <div id="ex-upload-status" class="mt-2 small" style="display:none;"></div>
+    </div>
+
     {% endif %}
 
     <!-- Registration form -->
@@ -350,7 +415,7 @@
       <!-- ── Logo — full width ── -->
       <h5 class="mb-2 mt-2">Event Logo <small class="text-muted fw-normal" style="font-size:0.75em;">optional — JPEG, PNG or WebP, max 5MB</small></h5>
       <div class="cl-dropzone mb-1" id="dropzone"
-           ondragover="onDragOver(event)" ondragleave="onDragLeave()" ondrop="onDrop(event)"
+           ondragover="onDragOver(event,'dropzone')" ondragleave="onDragLeave('dropzone')" ondrop="onDrop(event)"
            onclick="onDropzoneClick()">
         <div class="cl-dropzone-empty" id="dz-empty">
           Drag &amp; drop image here, or click to browse
@@ -456,13 +521,7 @@
   function onDropzoneClick() {
     if (!selectedFile) document.getElementById('file-input').click();
   }
-  function onDragOver(e) {
-    e.preventDefault();
-    document.getElementById('dropzone').classList.add('drag-over');
-  }
-  function onDragLeave() {
-    document.getElementById('dropzone').classList.remove('drag-over');
-  }
+  // onDragOver/onDragLeave are defined in the existing-logo section below (shared)
   function onDrop(e) {
     e.preventDefault();
     document.getElementById('dropzone').classList.remove('drag-over');
@@ -581,6 +640,161 @@
       btn.textContent = 'Copied!';
       setTimeout(function() { btn.textContent = orig; }, 1500);
     });
+  }
+
+  // ── Edit section show/hide + fetch event details ──────────────────────────
+  function showEditSection() {
+    document.getElementById('existing-section').style.display = 'none';
+    document.getElementById('edit-section').style.display     = 'block';
+
+    // Clear fields first
+    ['edit-eventname','edit-emailid','edit-eventdate','edit-eventenddate','edit-location','edit-eventpublic'].forEach(function(id) {
+      document.getElementById(id).value = 'Loading...';
+    });
+
+    var eventid = '{{ eventid }}';
+    fetch('/cloudlink/event-details?eventid=' + encodeURIComponent(eventid))
+      .then(function(r) { return r.json(); })
+      .then(function(data) {
+        if (data.success && data.event) {
+          var e = data.event;
+          document.getElementById('edit-eventname').value    = e.eventname    || '—';
+          document.getElementById('edit-emailid').value      = e.emailid      || '—';
+          document.getElementById('edit-eventdate').value    = e.eventdate    || '';
+          document.getElementById('edit-eventenddate').value = e.eventenddate || '';
+          var loc = [e.eventcity, e.eventcountry].filter(Boolean).join(', ');
+          document.getElementById('edit-location').value     = loc || '—';
+          document.getElementById('edit-eventpublic').value  = e.eventpublic === 'public' ? 'Public' : 'Private';
+        } else {
+          // API couldn't fetch — clear with a note
+          ['edit-eventname','edit-emailid','edit-location','edit-eventpublic'].forEach(function(id) {
+            document.getElementById(id).value = 'Could not load';
+          });
+          document.getElementById('edit-eventdate').value    = '';
+          document.getElementById('edit-eventenddate').value = '';
+        }
+      })
+      .catch(function() {
+        ['edit-eventname','edit-emailid','edit-location','edit-eventpublic'].forEach(function(id) {
+          document.getElementById(id).value = 'Could not load';
+        });
+      });
+  }
+  function hideEditSection() {
+    document.getElementById('edit-section').style.display     = 'none';
+    document.getElementById('existing-section').style.display = 'block';
+    clearExImage();
+    document.getElementById('ex-upload-status').style.display = 'none';
+  }
+
+  // ── Existing event logo upload ─────────────────────────────────────────────
+  var exSelectedFile = null;
+  var exPreviewUrl   = null;
+
+  function onExDropzoneClick() {
+    if (!exSelectedFile) document.getElementById('ex-file-input').click();
+  }
+  function onDragOver(e, id) {
+    e.preventDefault();
+    document.getElementById(id).classList.add('drag-over');
+  }
+  function onDragLeave(id) {
+    document.getElementById(id).classList.remove('drag-over');
+  }
+  function onExDrop(e) {
+    e.preventDefault();
+    document.getElementById('ex-dropzone').classList.remove('drag-over');
+    var file = e.dataTransfer && e.dataTransfer.files && e.dataTransfer.files[0];
+    if (file) handleExFile(file);
+  }
+  function onExFileSelected(e) {
+    var file = e.target.files && e.target.files[0];
+    if (file) handleExFile(file);
+  }
+  function handleExFile(file) {
+    document.getElementById('ex-upload-error').style.display = 'none';
+    var allowed = ['image/jpeg', 'image/png', 'image/webp'];
+    if (allowed.indexOf(file.type) === -1) {
+      document.getElementById('ex-upload-error').textContent = 'Only JPEG, PNG or WebP images are allowed.';
+      document.getElementById('ex-upload-error').style.display = 'block';
+      return;
+    }
+    if (file.size > 5 * 1024 * 1024) {
+      document.getElementById('ex-upload-error').textContent = 'Image must be under 5MB.';
+      document.getElementById('ex-upload-error').style.display = 'block';
+      return;
+    }
+    exSelectedFile = file;
+    if (exPreviewUrl) URL.revokeObjectURL(exPreviewUrl);
+    exPreviewUrl = URL.createObjectURL(file);
+    document.getElementById('ex-preview-img').src = exPreviewUrl;
+    document.getElementById('ex-dz-empty').style.display   = 'none';
+    document.getElementById('ex-dz-preview').style.display = 'block';
+    document.getElementById('ex-dropzone').classList.add('has-image');
+    document.getElementById('ex-upload-btn').disabled = false;
+  }
+  function clearExImage() {
+    exSelectedFile = null;
+    if (exPreviewUrl) { URL.revokeObjectURL(exPreviewUrl); exPreviewUrl = null; }
+    document.getElementById('ex-file-input').value = '';
+    document.getElementById('ex-preview-img').src = '';
+    document.getElementById('ex-dz-empty').style.display   = 'block';
+    document.getElementById('ex-dz-preview').style.display = 'none';
+    document.getElementById('ex-dropzone').classList.remove('has-image');
+    document.getElementById('ex-upload-btn').disabled = true;
+    document.getElementById('ex-upload-error').style.display = 'none';
+    document.getElementById('ex-upload-status').style.display = 'none';
+  }
+  function setExLoading(on) {
+    var btn = document.getElementById('ex-upload-btn');
+    var lbl = document.getElementById('ex-upload-label');
+    var spin = document.getElementById('ex-spinner');
+    btn.disabled = on;
+    spin.style.display = on ? 'inline-block' : 'none';
+    lbl.textContent = on ? 'Uploading...' : 'Upload Logo';
+  }
+  function showExStatus(msg, isError) {
+    var el = document.getElementById('ex-upload-status');
+    el.textContent = msg;
+    el.style.color = isError ? '#dc3545' : '#198754';
+    el.style.display = 'block';
+  }
+
+  function uploadExistingLogo() {
+    if (!exSelectedFile) return;
+    var eventid  = '{{ eventid }}';
+    var eventkey = '{{ eventkey }}';
+    if (!eventid || !eventkey) { showExStatus('No event keys found.', true); return; }
+
+    setExLoading(true);
+    document.getElementById('ex-upload-status').style.display = 'none';
+
+    var fd = new FormData();
+    fd.append('image_file', exSelectedFile, exSelectedFile.name);
+    fd.append('eventid',    eventid);
+    fd.append('eventkey',   eventkey);
+
+    fetch('/cloudlink/upload-logo', { method: 'POST', body: fd })
+      .then(function(r) { return r.json(); })
+      .then(function(data) {
+        setExLoading(false);
+        if (data.success) {
+          hideEditSection();
+          // Show success banner on the existing section
+          var banner = document.createElement('div');
+          banner.className = 'alert alert-success py-2 px-3 small mt-3';
+          banner.innerHTML = '<i class="bi bi-check-circle"></i> Event logo updated successfully!';
+          var ex = document.getElementById('existing-section');
+          ex.appendChild(banner);
+          setTimeout(function() { if (banner.parentNode) banner.parentNode.removeChild(banner); }, 4000);
+        } else {
+          showExStatus('Error: ' + (data.error || 'Upload failed'), true);
+        }
+      })
+      .catch(function() {
+        setExLoading(false);
+        showExStatus('Network error — check internet connection.', true);
+      });
   }
 </script>
 </body>

--- a/custom_plugins/cloudlink/templates/cloudlink/setup.html
+++ b/custom_plugins/cloudlink/templates/cloudlink/setup.html
@@ -12,8 +12,8 @@
 
     /* ── Navbar ── */
     .cl-navbar {
-      background: var(--color-interface-bg, #1a1a2e);
-      border-bottom: 2px solid hsl(var(--hue_1), var(--sat_1), var(--lum_1_high));
+      background: #ee7a28;
+      border-bottom: 2px solid #c45e10;
       padding: 0 1.25em;
       display: flex;
       align-items: center;
@@ -29,16 +29,22 @@
       gap: 0.5em;
       font-size: 1em;
       font-weight: 700;
-      color: var(--color-text, #dde);
+      color: #fff;
       text-decoration: none;
     }
     .cl-navbar-brand span.cl-brand-dim {
       font-weight: 400;
-      opacity: 0.55;
+      opacity: 0.75;
       font-size: 0.85em;
     }
     .cl-navbar-back {
       font-size: 0.85em;
+      color: #fff !important;
+      border-color: rgba(255,255,255,0.5) !important;
+    }
+    .cl-navbar-back:hover {
+      background: rgba(255,255,255,0.15) !important;
+      color: #fff !important;
     }
 
     .cl-page-wrap {

--- a/custom_plugins/cloudlink/templates/cloudlink/setup.html
+++ b/custom_plugins/cloudlink/templates/cloudlink/setup.html
@@ -1,0 +1,481 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CloudLink — Event Setup</title>
+  <link rel="stylesheet" href="/static/rotorhazard.css">
+  <link rel="icon" type="image/png" sizes="32x32" href="/static/image/favicon-32x32.png">
+  <style>
+    body { padding: 0; margin: 0; }
+
+    /* Header */
+    .cl-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 14px 24px;
+      border-bottom: 2px solid var(--color-interface-border, #2a4a6b);
+      background: var(--color-panel-bg, #1a3550);
+    }
+    .cl-header h1 { font-size: 1.2rem; margin: 0; color: #fff; }
+    .cl-badge {
+      font-size: 0.6rem; background: #ee7a28; color: #fff;
+      border-radius: 4px; padding: 2px 6px; font-weight: 700;
+      text-transform: uppercase; margin-left: 8px; vertical-align: middle;
+    }
+    .cl-back { font-size: 0.85rem; color: #ee7a28; text-decoration: none; }
+    .cl-back:hover { text-decoration: underline; }
+
+    /* Layout */
+    .cl-container { max-width: 660px; margin: 28px auto; padding: 0 20px 60px; }
+
+    /* Card */
+    .cl-card {
+      background: var(--color-panel-bg, #1e3d5c);
+      border: 1px solid var(--color-interface-border, #2a4a6b);
+      border-radius: 6px; padding: 22px; margin-bottom: 16px;
+    }
+    .cl-card-title {
+      font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.08em;
+      color: #ee7a28; margin: 0 0 16px; font-weight: 700;
+    }
+
+    /* Fields */
+    .cl-field { margin-bottom: 14px; }
+    .cl-field label {
+      display: block; font-size: 0.75rem; color: var(--color-text-secondary, #9ab);
+      margin-bottom: 4px; text-transform: uppercase; letter-spacing: 0.04em;
+    }
+    .cl-field input, .cl-field select, .cl-field textarea {
+      width: 100%; box-sizing: border-box;
+      background: var(--color-input-bg, #132d45);
+      border: 1px solid var(--color-interface-border, #2a4a6b);
+      border-radius: 4px; color: var(--color-text, #dde);
+      padding: 8px 11px; font-size: 0.9rem; font-family: inherit;
+      outline: none; transition: border-color 0.15s;
+    }
+    .cl-field input:focus, .cl-field textarea:focus, .cl-field select:focus { border-color: #ee7a28; }
+    .cl-field textarea { resize: vertical; min-height: 70px; }
+    .cl-field select { cursor: pointer; appearance: none; }
+    .cl-row { display: flex; gap: 14px; }
+    .cl-row .cl-field { flex: 1; }
+
+    /* Drop zone */
+    .cl-dropzone {
+      border: 2px dashed var(--color-interface-border, #2a4a6b);
+      border-radius: 6px; min-height: 100px;
+      display: flex; align-items: center; justify-content: center;
+      cursor: pointer; transition: border-color 0.15s, background 0.15s;
+      position: relative; overflow: hidden;
+      background: var(--color-input-bg, #132d45);
+    }
+    .cl-dropzone:hover, .cl-dropzone.drag-over {
+      border-color: #ee7a28; background: rgba(238,122,40,0.05);
+    }
+    .cl-dropzone.has-image { cursor: default; border-style: solid; border-color: #ee7a28; }
+    .cl-dropzone-empty { text-align: center; padding: 20px; pointer-events: none; }
+    .cl-dropzone-icon { font-size: 1.8rem; display: block; margin-bottom: 6px; opacity: 0.5; }
+    .cl-dropzone-text { font-size: 0.85rem; color: var(--color-text-secondary, #9ab); margin: 0; }
+    .cl-dropzone-link { color: #ee7a28; text-decoration: underline; }
+    .cl-dropzone-hint { font-size: 0.72rem; color: var(--color-text-secondary, #9ab); margin-top: 4px; }
+    .cl-dropzone-preview { width: 100%; height: 110px; position: relative; }
+    .cl-preview-img { width: 100%; height: 100%; object-fit: cover; display: block; }
+    .cl-preview-remove {
+      position: absolute; top: 6px; right: 6px;
+      background: rgba(200,60,60,0.85); color: #fff;
+      border: none; border-radius: 50%; width: 24px; height: 24px;
+      font-size: 0.8rem; cursor: pointer; display: flex;
+      align-items: center; justify-content: center;
+    }
+    .cl-upload-error { font-size: 0.78rem; color: #f88; margin-top: 6px; display: none; }
+    .cl-upload-status { font-size: 0.78rem; color: var(--color-text-secondary, #9ab); margin-top: 6px; display: none; }
+
+    /* Buttons */
+    .cl-btn {
+      display: inline-flex; align-items: center; gap: 7px;
+      padding: 9px 22px; border-radius: 4px; font-size: 0.9rem;
+      font-weight: 600; cursor: pointer; border: none;
+      font-family: inherit; letter-spacing: 0.02em; transition: opacity 0.15s;
+    }
+    .cl-btn-primary { background: #ee7a28; color: #fff; }
+    .cl-btn-primary:hover { opacity: 0.87; }
+    .cl-btn-primary:disabled { opacity: 0.4; cursor: not-allowed; }
+    .cl-btn-secondary { background: transparent; color: #ee7a28; border: 1px solid #ee7a28; }
+    .cl-btn-secondary:hover { background: rgba(238,122,40,0.1); }
+    .cl-btn-row { display: flex; gap: 10px; align-items: center; flex-wrap: wrap; }
+
+    /* Spinner */
+    .cl-spinner {
+      width: 14px; height: 14px; border: 2px solid rgba(255,255,255,0.25);
+      border-top-color: #fff; border-radius: 50%;
+      animation: spin 0.65s linear infinite; display: none;
+    }
+    .submitting .cl-spinner { display: block; }
+    .submitting .cl-btn-label { opacity: 0.7; }
+    @keyframes spin { to { transform: rotate(360deg); } }
+
+    /* Status */
+    .cl-status {
+      font-size: 0.82rem; padding: 9px 13px; border-radius: 4px;
+      margin-top: 12px; display: none;
+    }
+    .cl-status.error { background: rgba(200,60,60,0.15); border: 1px solid rgba(200,60,60,0.35); color: #f88; }
+    .cl-status.info  { background: rgba(238,122,40,0.1);  border: 1px solid rgba(238,122,40,0.3);  color: #ee7a28; }
+
+    /* Existing keys */
+    .cl-key-row { display: flex; align-items: center; gap: 8px; margin-top: 6px; }
+    .cl-key-box {
+      flex: 1; background: var(--color-input-bg, #132d45);
+      border: 1px solid var(--color-interface-border, #2a4a6b);
+      border-radius: 4px; padding: 7px 11px;
+      font-family: monospace; font-size: 0.95rem; color: #ee7a28; letter-spacing: 0.05em;
+    }
+    .cl-copy-btn {
+      background: none; border: 1px solid var(--color-interface-border, #2a4a6b);
+      border-radius: 4px; color: var(--color-text-secondary, #9ab);
+      padding: 6px 10px; cursor: pointer; font-size: 0.72rem; white-space: nowrap;
+    }
+    .cl-copy-btn:hover { border-color: #ee7a28; color: #ee7a28; }
+
+    /* Success */
+    #success-section { display: none; }
+    .cl-success-icon { font-size: 2.2rem; text-align: center; margin-bottom: 10px; }
+    .cl-success-msg {
+      text-align: center; font-size: 0.88rem;
+      color: var(--color-text-secondary, #9ab); margin-bottom: 20px; line-height: 1.5;
+    }
+    .cl-success-msg strong { color: var(--color-text, #dde); }
+  </style>
+</head>
+<body>
+
+<div class="cl-header">
+  <h1>CloudLink <span class="cl-badge">Event Setup</span></h1>
+  <a class="cl-back" href="/format">← Back to Format</a>
+</div>
+
+<div class="cl-container">
+
+  <!-- ── Already registered ── -->
+  {% if eventid and eventkey %}
+  <div class="cl-card" id="existing-section">
+    <div class="cl-card-title">✅ Event Registered</div>
+    <div class="cl-field">
+      <label>Event ID</label>
+      <div class="cl-key-row">
+        <div class="cl-key-box">{{ eventid }}</div>
+        <button class="cl-copy-btn" onclick="copyText('{{ eventid }}', this)">Copy</button>
+      </div>
+    </div>
+    <div class="cl-field">
+      <label>Private Key</label>
+      <div class="cl-key-row">
+        <div class="cl-key-box">{{ eventkey }}</div>
+        <button class="cl-copy-btn" onclick="copyText('{{ eventkey }}', this)">Copy</button>
+      </div>
+    </div>
+    <div class="cl-btn-row" style="margin-top:18px;">
+      <a class="cl-btn cl-btn-primary" href="/format">Done — Back to Format</a>
+      <button class="cl-btn cl-btn-secondary" onclick="showForm()">Register a Different Event</button>
+    </div>
+  </div>
+  {% endif %}
+
+  <!-- ── Registration form ── -->
+  <div id="form-section" {% if eventid and eventkey %}style="display:none"{% endif %}>
+
+    <!-- Event Details -->
+    <div class="cl-card">
+      <div class="cl-card-title">Event Details</div>
+
+      <div class="cl-field">
+        <label>Event Name *</label>
+        <input type="text" id="eventname" placeholder="e.g. UGKL FPV Round 3" maxlength="100">
+      </div>
+
+      <div class="cl-field">
+        <label>Race Director Email *</label>
+        <input type="text" id="emailid" placeholder="e.g. director@example.com" maxlength="254">
+      </div>
+
+      <div class="cl-row">
+        <div class="cl-field">
+          <label>Start Date</label>
+          <input type="date" id="eventdate">
+        </div>
+        <div class="cl-field">
+          <label>End Date</label>
+          <input type="date" id="eventenddate">
+        </div>
+      </div>
+
+      <div class="cl-row">
+        <div class="cl-field">
+          <label>City</label>
+          <input type="text" id="eventcity" placeholder="e.g. Kuala Lumpur" maxlength="100">
+        </div>
+        <div class="cl-field">
+          <label>Country</label>
+          <input type="text" id="eventcountry" placeholder="e.g. Malaysia" maxlength="100">
+        </div>
+      </div>
+
+      <div class="cl-field">
+        <label>Visibility</label>
+        <select id="eventpublic">
+          <option value="private">🔒 Private — not listed publicly</option>
+          <option value="public">🌐 Public — shown on CloudLink events page</option>
+        </select>
+      </div>
+
+      <div class="cl-field">
+        <label>Description</label>
+        <textarea id="eventdesc" placeholder="Brief description of the event..." maxlength="500"></textarea>
+      </div>
+    </div>
+
+    <!-- Event Logo -->
+    <div class="cl-card">
+      <div class="cl-card-title">Event Logo <span style="font-size:0.7rem;text-transform:none;color:var(--color-text-secondary,#9ab);letter-spacing:0;">(optional — JPEG, PNG or WebP, max 5MB)</span></div>
+
+      <div class="cl-dropzone" id="dropzone"
+           ondragover="onDragOver(event)" ondragleave="onDragLeave()" ondrop="onDrop(event)"
+           onclick="onDropzoneClick()">
+
+        <div class="cl-dropzone-empty" id="dz-empty">
+          <span class="cl-dropzone-icon">🖼️</span>
+          <p class="cl-dropzone-text">Drag &amp; drop your logo here<br>
+            or <span class="cl-dropzone-link">click to browse</span></p>
+          <p class="cl-dropzone-hint">JPEG, PNG, WebP · max 5MB</p>
+        </div>
+
+        <div class="cl-dropzone-preview" id="dz-preview" style="display:none">
+          <img class="cl-preview-img" id="preview-img" src="" alt="Preview">
+          <button class="cl-preview-remove" onclick="event.stopPropagation(); clearImage()" title="Remove">✕</button>
+        </div>
+      </div>
+
+      <input type="file" id="file-input" accept="image/jpeg,image/png,image/webp" style="display:none" onchange="onFileSelected(event)">
+      <div class="cl-upload-error" id="upload-error"></div>
+      <div class="cl-upload-status" id="upload-status"></div>
+    </div>
+
+    <!-- Submit -->
+    <div class="cl-card">
+      <div class="cl-btn-row">
+        <button class="cl-btn cl-btn-primary" id="submit-btn" onclick="submitForm()">
+          <span class="cl-spinner"></span>
+          <span class="cl-btn-label">Register Event</span>
+        </button>
+        {% if eventid and eventkey %}
+        <button class="cl-btn cl-btn-secondary" onclick="cancelForm()">Cancel</button>
+        {% endif %}
+      </div>
+      <div class="cl-status" id="form-status"></div>
+    </div>
+
+  </div><!-- /form-section -->
+
+  <!-- ── Success ── -->
+  <div id="success-section">
+    <div class="cl-card">
+      <div class="cl-success-icon">🎉</div>
+      <div class="cl-success-msg">
+        Event registered!<br>
+        <strong>Keys saved to your timer automatically.</strong><br>
+        Head back to Format to start racing.
+      </div>
+      <div class="cl-field">
+        <label>Event ID</label>
+        <div class="cl-key-row">
+          <div class="cl-key-box" id="new-eventid">—</div>
+          <button class="cl-copy-btn" onclick="copyText(document.getElementById('new-eventid').textContent, this)">Copy</button>
+        </div>
+      </div>
+      <div class="cl-field">
+        <label>Private Key</label>
+        <div class="cl-key-row">
+          <div class="cl-key-box" id="new-eventkey">—</div>
+          <button class="cl-copy-btn" onclick="copyText(document.getElementById('new-eventkey').textContent, this)">Copy</button>
+        </div>
+      </div>
+      <div class="cl-btn-row" style="margin-top:18px;">
+        <a class="cl-btn cl-btn-primary" href="/format">Done — Back to Format</a>
+        <button class="cl-btn cl-btn-secondary" onclick="registerAnother()">Register Another</button>
+      </div>
+    </div>
+  </div>
+
+</div><!-- /cl-container -->
+
+<script>
+  // ── State ──────────────────────────────────────────────────────────────────
+  var selectedFile = null;
+  var previewUrl   = null;
+
+  // ── Init ───────────────────────────────────────────────────────────────────
+  var today = new Date().toISOString().split('T')[0];
+  document.getElementById('eventdate').value    = today;
+  document.getElementById('eventenddate').value = today;
+
+  // ── Drag & Drop ────────────────────────────────────────────────────────────
+  function onDropzoneClick() {
+    if (!selectedFile) document.getElementById('file-input').click();
+  }
+  function onDragOver(e) {
+    e.preventDefault();
+    document.getElementById('dropzone').classList.add('drag-over');
+  }
+  function onDragLeave() {
+    document.getElementById('dropzone').classList.remove('drag-over');
+  }
+  function onDrop(e) {
+    e.preventDefault();
+    document.getElementById('dropzone').classList.remove('drag-over');
+    var file = e.dataTransfer && e.dataTransfer.files && e.dataTransfer.files[0];
+    if (file) handleFile(file);
+  }
+  function onFileSelected(e) {
+    var file = e.target.files && e.target.files[0];
+    if (file) handleFile(file);
+  }
+
+  // ── File handling ──────────────────────────────────────────────────────────
+  function handleFile(file) {
+    hideUploadError();
+
+    var allowed = ['image/jpeg', 'image/png', 'image/webp'];
+    if (allowed.indexOf(file.type) === -1) {
+      showUploadError('Only JPEG, PNG or WebP images are allowed.');
+      return;
+    }
+    if (file.size > 5 * 1024 * 1024) {
+      showUploadError('Image must be under 5MB.');
+      return;
+    }
+
+    selectedFile = file;
+    if (previewUrl) URL.revokeObjectURL(previewUrl);
+    previewUrl = URL.createObjectURL(file);
+
+    document.getElementById('preview-img').src = previewUrl;
+    document.getElementById('dz-empty').style.display   = 'none';
+    document.getElementById('dz-preview').style.display = 'block';
+    document.getElementById('dropzone').classList.add('has-image');
+  }
+
+  function clearImage() {
+    selectedFile = null;
+    if (previewUrl) { URL.revokeObjectURL(previewUrl); previewUrl = null; }
+    document.getElementById('file-input').value = '';
+    document.getElementById('preview-img').src = '';
+    document.getElementById('dz-empty').style.display   = 'block';
+    document.getElementById('dz-preview').style.display = 'none';
+    document.getElementById('dropzone').classList.remove('has-image');
+    hideUploadError();
+    hideUploadStatus();
+  }
+
+  // ── Submit ─────────────────────────────────────────────────────────────────
+  function submitForm() {
+    var eventname = document.getElementById('eventname').value.trim();
+    var emailid   = document.getElementById('emailid').value.trim();
+
+    if (!eventname) { showStatus('Event name is required.', 'error'); return; }
+    if (!emailid)   { showStatus('Email address is required.', 'error'); return; }
+
+    hideStatus();
+    setLoading(true);
+
+    var fd = new FormData();
+    fd.append('eventname',    eventname);
+    fd.append('emailid',      emailid);
+    fd.append('eventdate',    document.getElementById('eventdate').value);
+    fd.append('eventenddate', document.getElementById('eventenddate').value || document.getElementById('eventdate').value);
+    fd.append('eventcity',    document.getElementById('eventcity').value.trim());
+    fd.append('eventcountry', document.getElementById('eventcountry').value.trim());
+    fd.append('eventdesc',    document.getElementById('eventdesc').value.trim());
+    fd.append('eventpublic',  document.getElementById('eventpublic').value);
+    fd.append('has_image',    selectedFile ? 'true' : 'false');
+
+    if (selectedFile) {
+      fd.append('image_file', selectedFile, selectedFile.name);
+      showStatus('Creating event...', 'info');
+    }
+
+    fetch('/cloudlink/register', { method: 'POST', body: fd })
+      .then(function(r) { return r.json(); })
+      .then(function(data) {
+        setLoading(false);
+        if (data.success) {
+          document.getElementById('new-eventid').textContent  = data.eventid;
+          document.getElementById('new-eventkey').textContent = data.privatekey;
+          document.getElementById('form-section').style.display    = 'none';
+          document.getElementById('success-section').style.display = 'block';
+          var ex = document.getElementById('existing-section');
+          if (ex) ex.style.display = 'none';
+        } else {
+          showStatus('Error: ' + (data.error || 'Registration failed'), 'error');
+        }
+      })
+      .catch(function() {
+        setLoading(false);
+        showStatus('Network error — check internet connection.', 'error');
+      });
+  }
+
+  // ── Helpers ────────────────────────────────────────────────────────────────
+  function setLoading(loading) {
+    var btn = document.getElementById('submit-btn');
+    if (loading) { btn.classList.add('submitting'); btn.disabled = true; }
+    else         { btn.classList.remove('submitting'); btn.disabled = false; }
+  }
+  function showStatus(msg, type) {
+    var el = document.getElementById('form-status');
+    el.textContent = msg; el.className = 'cl-status ' + type; el.style.display = 'block';
+  }
+  function hideStatus() { document.getElementById('form-status').style.display = 'none'; }
+  function showUploadError(msg) {
+    var el = document.getElementById('upload-error');
+    el.textContent = msg; el.style.display = 'block';
+  }
+  function hideUploadError() { document.getElementById('upload-error').style.display = 'none'; }
+  function showUploadStatus(msg) {
+    var el = document.getElementById('upload-status');
+    el.textContent = msg; el.style.display = 'block';
+  }
+  function hideUploadStatus() { document.getElementById('upload-status').style.display = 'none'; }
+
+  function showForm() {
+    document.getElementById('existing-section').style.display = 'none';
+    document.getElementById('form-section').style.display     = 'block';
+  }
+  function cancelForm() {
+    document.getElementById('form-section').style.display     = 'none';
+    document.getElementById('existing-section').style.display = 'block';
+  }
+  function registerAnother() {
+    document.getElementById('success-section').style.display = 'none';
+    document.getElementById('form-section').style.display    = 'block';
+    document.getElementById('eventname').value    = '';
+    document.getElementById('emailid').value      = '';
+    document.getElementById('eventdate').value    = today;
+    document.getElementById('eventenddate').value = today;
+    document.getElementById('eventcity').value    = '';
+    document.getElementById('eventcountry').value = '';
+    document.getElementById('eventpublic').value  = 'private';
+    document.getElementById('eventdesc').value    = '';
+    clearImage();
+    hideStatus();
+  }
+  function copyText(text, btn) {
+    navigator.clipboard.writeText(text).then(function() {
+      var orig = btn.textContent;
+      btn.textContent = 'Copied!';
+      setTimeout(function() { btn.textContent = orig; }, 1500);
+    });
+  }
+</script>
+</body>
+</html>


### PR DESCRIPTION
Clean rebuild of the in-timer registration UI.

## Flow (mirrors Angular registration page exactly)
1. `POST /register` → get eventid + privatekey
2. `POST /uploads/presign` → get uploadUrl + publicUrl
3. `PUT {uploadUrl}` → image bytes direct to S3 (presigned, no auth header needed)
4. `PATCH /event/{id}` → save eventlogourl with X-Private-Key
5. Keys auto-saved to RH options

## Features
- Drag & drop image upload — JPEG, PNG, WebP, max 5MB
- All fields: name, email, start/end date, city, country, visibility, description
- Works from any IP/domain — S3 CORS and API CORS both `*`
- Setup button in Format panel → opens `/cloudlink/setup`
- Shows existing keys if already registered, option to re-register

## Files
- `registration_blueprint.py` — Flask Blueprint, all server-side logic
- `templates/cloudlink/setup.html` — UI, drag/drop, JS flow
- `cloudlink.py` — blueprint wiring + Setup button in panel