### PR TITLE
feat: pilot image upload setting + photo_url in results

### DIFF
--- a/custom_plugins/cloudlink/cloudlink.py
+++ b/custom_plugins/cloudlink/cloudlink.py
@@ -74,6 +74,23 @@ class CloudLink():
         except Exception as e:
             self.logger.error(f"CloudLink: failed to register blueprint: {e}")
 
+    def get_pilot_photo_url(self, pilot_id):
+        """
+        Returns the pilot's photo URL if the upload-pilot-image setting is ON
+        and the pilot has a photo attribute set.
+        Attribute name TBC — will be confirmed and updated tonight.
+        """
+        if self._rhapi.db.option("cl-upload-pilot-image") != "1":
+            return None
+        try:
+            # TODO: Replace 'mgp_url' with the confirmed MultiGP Toolkit attribute name
+            photo_url = self._rhapi.db.pilot_attribute_value(pilot_id, 'mgp_url')
+            if photo_url and str(photo_url).strip():
+                return str(photo_url).strip()
+        except Exception:
+            pass
+        return None
+
     def resync_new(self, args):
      
         keys = self.getEventKeys()
@@ -361,6 +378,11 @@ class CloudLink():
                             "displayname": result["consecutives_source"]["displayname"],
                         } if "consecutives_source" in result and result["consecutives_source"] is not None else None,
                     }
+
+                    photo_url = self.get_pilot_photo_url(result["pilot_id"])
+                    if photo_url:
+                        pilot["photo_url"] = photo_url
+
                     resultpayload.append(pilot)
 
                 payload = {

--- a/custom_plugins/cloudlink/cloudlink.py
+++ b/custom_plugins/cloudlink/cloudlink.py
@@ -78,7 +78,7 @@ class CloudLink():
         """
         Returns the pilot's photo URL if the upload-pilot-image setting is ON
         and the pilot has a photo attribute set.
-        Attribute name TBC — will be confirmed and updated tonight.
+        Reads PilotDetailPhotoURL set by MultiGP Toolkit from profilePictureUrl.
         """
         if self._rhapi.db.option("cl-upload-pilot-image") != "1":
             return None

--- a/custom_plugins/cloudlink/cloudlink.py
+++ b/custom_plugins/cloudlink/cloudlink.py
@@ -57,11 +57,13 @@ class CloudLink():
         cl_enableplugin = UIField(name='cl-enable-plugin', label='Enable Cloud Link Plugin', field_type=UIFieldType.CHECKBOX, desc="Enable or disable this plugin.")
         cl_eventid  = UIField(name='cl-event-id',  label='Cloud Link Event ID',          field_type=UIFieldType.TEXT, desc="Event ID from rhcloudlink.com/register or the in-timer setup page.")
         cl_eventkey = UIField(name='cl-event-key', label='Cloud Link Event Private Key', field_type=UIFieldType.TEXT, desc="Private key provided after registration. Keep this safe.")
+        cl_upload_pilot_image = UIField(name='cl-upload-pilot-image', label='Upload Pilot Image', field_type=UIFieldType.CHECKBOX, desc="Send pilot photo URL to CloudLink when available.")
 
         fields = self._rhapi.fields
-        fields.register_option(cl_enableplugin, "cloud-link")
-        fields.register_option(cl_eventid,      "cloud-link")
-        fields.register_option(cl_eventkey,     "cloud-link")
+        fields.register_option(cl_enableplugin,        "cloud-link")
+        fields.register_option(cl_eventid,             "cloud-link")
+        fields.register_option(cl_eventkey,            "cloud-link")
+        fields.register_option(cl_upload_pilot_image,  "cloud-link")
 
         # Register the Flask blueprint for the in-timer registration UI
         try:

--- a/custom_plugins/cloudlink/cloudlink.py
+++ b/custom_plugins/cloudlink/cloudlink.py
@@ -83,8 +83,7 @@ class CloudLink():
         if self._rhapi.db.option("cl-upload-pilot-image") != "1":
             return None
         try:
-            # TODO: Replace 'mgp_url' with the confirmed MultiGP Toolkit attribute name
-            photo_url = self._rhapi.db.pilot_attribute_value(pilot_id, 'mgp_url')
+            photo_url = self._rhapi.db.pilot_attribute_value(pilot_id, 'PilotDetailPhotoURL')
             if photo_url and str(photo_url).strip():
                 return str(photo_url).strip()
         except Exception:

--- a/custom_plugins/cloudlink/datamanager.py
+++ b/custom_plugins/cloudlink/datamanager.py
@@ -70,6 +70,21 @@ class ClDataManager():
 
         return clslist
     
+    def _get_pilot_photo_url(self, pilot_id):
+        """
+        Returns the pilot's photo URL if the upload-pilot-image setting is ON.
+        TODO: Replace 'mgp_url' with the confirmed MultiGP Toolkit attribute name.
+        """
+        if self._rhapi.db.option("cl-upload-pilot-image") != "1":
+            return None
+        try:
+            photo_url = self._rhapi.db.pilot_attribute_value(pilot_id, 'mgp_url')
+            if photo_url and str(photo_url).strip():
+                return str(photo_url).strip()
+        except Exception:
+            pass
+        return None
+
     def get_class_results(self):
         clss = self._rhapi.db.raceclasses
         overallresults = []
@@ -107,8 +122,12 @@ class ClDataManager():
                             "heat": result["consecutives_source"]["heat"],
                             "displayname": result["consecutives_source"]["displayname"],
                         } if "consecutives_source" in result and result["consecutives_source"] is not None else None,
-                        
                     }
+
+                    photo_url = self._get_pilot_photo_url(result["pilot_id"])
+                    if photo_url:
+                        resultobj["photo_url"] = photo_url
+
                     finalresults.append(resultobj)
 
             thisclassresults = {

--- a/custom_plugins/cloudlink/datamanager.py
+++ b/custom_plugins/cloudlink/datamanager.py
@@ -73,12 +73,12 @@ class ClDataManager():
     def _get_pilot_photo_url(self, pilot_id):
         """
         Returns the pilot's photo URL if the upload-pilot-image setting is ON.
-        TODO: Replace 'mgp_url' with the confirmed MultiGP Toolkit attribute name.
+        Reads the PilotDetailPhotoURL attribute set by MultiGP Toolkit.
         """
         if self._rhapi.db.option("cl-upload-pilot-image") != "1":
             return None
         try:
-            photo_url = self._rhapi.db.pilot_attribute_value(pilot_id, 'mgp_url')
+            photo_url = self._rhapi.db.pilot_attribute_value(pilot_id, 'PilotDetailPhotoURL')
             if photo_url and str(photo_url).strip():
                 return str(photo_url).strip()
         except Exception:

--- a/custom_plugins/cloudlink/registration_blueprint.py
+++ b/custom_plugins/cloudlink/registration_blueprint.py
@@ -305,4 +305,33 @@ def create_registration_blueprint(rhapi):
         logger.info('[CloudLink] Keys cleared')
         return jsonify({'success': True})
 
+    # ──────────────────────────────────────────────────────────────────────────
+    # GET /cloudlink/settings — return current settings as JSON
+    # ──────────────────────────────────────────────────────────────────────────
+    @bp.route('/settings', methods=['GET'])
+    def get_settings():
+        upload_pilot_image = rhapi.db.option('cl-upload-pilot-image') == '1'
+        return jsonify({
+            'success': True,
+            'settings': {
+                'upload_pilot_image': upload_pilot_image
+            }
+        })
+
+    # ──────────────────────────────────────────────────────────────────────────
+    # POST /cloudlink/settings — save settings
+    # ──────────────────────────────────────────────────────────────────────────
+    @bp.route('/settings', methods=['POST'])
+    def save_settings():
+        try:
+            data = request.get_json(force=True) or {}
+            if 'upload_pilot_image' in data:
+                val = '1' if data['upload_pilot_image'] else '0'
+                rhapi.db.option_set('cl-upload-pilot-image', val)
+                logger.info(f'[CloudLink] upload_pilot_image set to {val}')
+            return jsonify({'success': True})
+        except Exception as e:
+            logger.error(f'[CloudLink] Settings save error: {e}')
+            return jsonify({'success': False, 'error': str(e)}), 500
+
     return bp

--- a/custom_plugins/cloudlink/templates/cloudlink/setup.html
+++ b/custom_plugins/cloudlink/templates/cloudlink/setup.html
@@ -261,6 +261,12 @@
         <i class="bi bi-broadcast cl-nav-icon"></i> Realtime Update
       </a>
     </li>
+    <li class="cl-sidebar-divider"></li>
+    <li>
+      <a href="#" onclick="showTab('settings', this)">
+        <i class="bi bi-gear cl-nav-icon"></i> Settings
+      </a>
+    </li>
   </ul>
 </aside>
 
@@ -481,6 +487,41 @@
     <p class="text-muted">Realtime sync status and controls will appear here.</p>
   </div>
 
+  <!-- ══ TAB: Settings ══ -->
+  <div id="tab-settings" style="display:none">
+    <h5 class="mb-1">Settings</h5>
+    <p class="text-muted small mb-4">Configure how Cloudlink behaves during your event.</p>
+
+    <div class="row g-4">
+      <!-- Col 1: Pilot Settings -->
+      <div class="col-12 col-md-6">
+        <div class="card border-0 shadow-sm h-100">
+          <div class="card-body">
+            <h6 class="card-title mb-3">
+              <i class="bi bi-person-badge" style="color:var(--cl-orange)"></i> Pilot Data
+            </h6>
+            <div class="form-check form-switch">
+              <input class="form-check-input" type="checkbox" role="switch" id="setting-upload-pilot-image" onchange="onSettingChange()">
+              <label class="form-check-label" for="setting-upload-pilot-image">
+                Upload pilot image if available
+              </label>
+            </div>
+            <p class="text-muted small mt-2 mb-0">
+              When enabled, Cloudlink will send the pilot's photo URL to the cloud with race results, if one is available on the pilot profile.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <!-- Col 2: reserved for future settings -->
+      <div class="col-12 col-md-6">
+        <!-- future settings go here -->
+      </div>
+    </div>
+
+    <div id="settings-status" class="mt-3 small" style="display:none;"></div>
+  </div>
+
 </main>
 
 <script>
@@ -503,7 +544,7 @@
   // ── Tab switching ──────────────────────────────────────────────────────────
   function showTab(tabId, linkEl) {
     // hide all tabs
-    ['event-setup', 'bracket-config', 'realtime'].forEach(function(t) {
+    ['event-setup', 'bracket-config', 'realtime', 'settings'].forEach(function(t) {
       document.getElementById('tab-' + t).style.display = 'none';
     });
     // show selected
@@ -515,6 +556,50 @@
     if (linkEl) linkEl.classList.add('active');
     // close sidebar on mobile after selection
     closeSidebar();
+    // load settings when navigating to settings tab
+    if (tabId === 'settings') loadSettings();
+  }
+
+  // ── Settings ───────────────────────────────────────────────────────────────
+  function loadSettings() {
+    fetch('/cloudlink/settings')
+      .then(function(r) { return r.json(); })
+      .then(function(data) {
+        if (data.success) {
+          document.getElementById('setting-upload-pilot-image').checked = data.settings.upload_pilot_image;
+        }
+      })
+      .catch(function() { showSettingsStatus('Could not load settings.', true); });
+  }
+
+  function onSettingChange() {
+    var payload = {
+      upload_pilot_image: document.getElementById('setting-upload-pilot-image').checked
+    };
+    fetch('/cloudlink/settings', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    })
+      .then(function(r) { return r.json(); })
+      .then(function(data) {
+        if (data.success) {
+          showSettingsStatus('✓ Saved', false);
+          setTimeout(function() {
+            document.getElementById('settings-status').style.display = 'none';
+          }, 2000);
+        } else {
+          showSettingsStatus('Failed to save: ' + (data.error || 'unknown error'), true);
+        }
+      })
+      .catch(function() { showSettingsStatus('Network error — setting not saved.', true); });
+  }
+
+  function showSettingsStatus(msg, isError) {
+    var el = document.getElementById('settings-status');
+    el.textContent = msg;
+    el.style.color = isError ? '#dc3545' : '#198754';
+    el.style.display = 'block';
   }
 
   // ── Drag & Drop ────────────────────────────────────────────────────────────


### PR DESCRIPTION
## What
Adds a Settings tab to the in-timer setup page with a persistent toggle to enable pilot photo upload to CloudLink.

## Changes

### Settings UI
- New **Settings** nav entry in sidebar (setup page)
- 2-column card layout — easy to add more settings in future
- Checkbox: **Upload pilot image if available** (default OFF)
- Auto-saves on toggle via `POST /cloudlink/settings`
- Persists across timer restarts via RH local DB (`cl-upload-pilot-image` option)

### Pilot Photo Upload
- Reads `PilotDetailPhotoURL` attribute set by MultiGP Toolkit
- Adds `photo_url` to results payload when setting is ON and URL is available
- Triggered on all 3 result push paths:
  1. Race save (race director hits Save)
  2. Marshall commit
  3. Resync button on Format page
- Field omitted entirely when not available — no API breakage

### API
- `GET /cloudlink/settings` — returns current settings as JSON
- `POST /cloudlink/settings` — saves settings to RH DB